### PR TITLE
fix: reload user from DB to prevent download count reset

### DIFF
--- a/apps/api/src/app/users/users.service.spec.ts
+++ b/apps/api/src/app/users/users.service.spec.ts
@@ -415,15 +415,18 @@ describe('UsersService', () => {
   });
 
   describe('updateLastConnection', () => {
-    it('should update last connection date', async () => {
-      mockMyCalibreDbService.saveUser.mockResolvedValue(mockUser);
-      const user = { ...mockUser };
-      const oldDate = user.history.lastConnection;
+    it('should reload user from DB before updating last connection', async () => {
+      const freshUser = { ...mockUser, history: { ...mockUser.history, lastConnection: new Date('2023-01-01') } };
+      mockMyCalibreDbService.findUserById.mockResolvedValue(freshUser);
+      mockMyCalibreDbService.saveUser.mockResolvedValue(freshUser);
 
-      await service.updateLastConnection(user);
+      const staleUser = { ...mockUser };
 
-      expect(user.history.lastConnection.getTime()).toBeGreaterThan(oldDate.getTime());
-      expect(mockMyCalibreDbService.saveUser).toHaveBeenCalledWith(user, true, false);
+      await service.updateLastConnection(staleUser);
+
+      expect(mockMyCalibreDbService.findUserById).toHaveBeenCalledWith('user123');
+      expect(freshUser.history.lastConnection.getTime()).toBeGreaterThan(new Date('2023-01-01').getTime());
+      expect(mockMyCalibreDbService.saveUser).toHaveBeenCalledWith(freshUser, true, false);
     });
   });
 
@@ -471,15 +474,19 @@ describe('UsersService', () => {
   });
 
   describe('addRatingBook', () => {
-    it('should add a book rating', async () => {
-      const user = { ...mockUser, history: { ...mockUser.history, ratings: [] } };
-      mockMyCalibreDbService.saveUser.mockResolvedValue(user);
+    it('should reload user from DB before modifying ratings', async () => {
+      const freshUser = { ...mockUser, history: { ...mockUser.history, ratings: [], downloadedBooks: [{ id: 999, data: { data_id: 1, data_format: 'EPUB', data_size: 100, data_name: 'existing-book' }, date: new Date() }] } };
+      mockMyCalibreDbService.findUserById.mockResolvedValue(freshUser);
+      mockMyCalibreDbService.saveUser.mockResolvedValue(freshUser);
 
-      await service.addRatingBook(user, 123, 'Test Book', 5);
+      const staleUser = { ...mockUser, history: { ...mockUser.history, ratings: [], downloadedBooks: [] } };
 
-      expect(user.history.ratings.length).toBe(1);
-      expect(user.history.ratings[0].book_id).toBe(123);
-      expect(user.history.ratings[0].rating).toBe(5);
+      await service.addRatingBook(staleUser, 123, 'Test Book', 5);
+
+      expect(mockMyCalibreDbService.findUserById).toHaveBeenCalledWith('user123');
+      expect(freshUser.history.ratings.length).toBe(1);
+      expect(freshUser.history.ratings[0].book_id).toBe(123);
+      expect(freshUser.history.ratings[0].rating).toBe(5);
       expect(mockMyCalibreDbService.saveUser).toHaveBeenCalled();
     });
 
@@ -491,6 +498,7 @@ describe('UsersService', () => {
           ratings: [{ book_id: 123, rating: 3, date: new Date('2023-01-01'), book_name: 'Test Book' }],
         },
       };
+      mockMyCalibreDbService.findUserById.mockResolvedValue(user);
       mockMyCalibreDbService.saveUser.mockResolvedValue(user);
 
       await service.addRatingBook(user, 123, 'Test Book', 5);
@@ -509,6 +517,7 @@ describe('UsersService', () => {
           ratings: [{ book_id: 123, rating: 5, date: existingDate, book_name: 'Test Book' }],
         },
       };
+      mockMyCalibreDbService.findUserById.mockResolvedValue(user);
       mockMyCalibreDbService.saveUser.mockResolvedValue(user);
 
       await service.addRatingBook(user, 123, 'Test Book', 5);

--- a/apps/api/src/app/users/users.service.ts
+++ b/apps/api/src/app/users/users.service.ts
@@ -482,13 +482,14 @@ export class UsersService {
     return user;
   }
 
-  updateLastConnection(user: User) {
-    user.history.lastConnection = new Date();
-    this.saveUser(user, false).catch((err) => {
-      if (err) {
-        this.logger.error(err);
-      }
-    });
+  async updateLastConnection(userIn: User) {
+    try {
+      const user = await this.findById(userIn.id);
+      user.history.lastConnection = new Date();
+      await this.saveUser(user, false);
+    } catch (err) {
+      this.logger.error(err);
+    }
   }
   async addDownloadedBook(userIn: User, book_id: number, bookData: BookData): Promise<void> {
     try {
@@ -527,43 +528,44 @@ export class UsersService {
       throw reason;
     }
   }
-  async addRatingBook(user: User, book_id: number, bookName: string, rating: number): Promise<void> {
-    if (!user.history.ratings) {
-      user.history.ratings = [];
-    }
-    let bookRating = user.history.ratings.find((br) => {
-      return br.book_id === book_id;
-    });
-    if (!bookRating) {
-      bookRating = {
-        book_id: book_id,
-        rating: undefined,
-        date: undefined,
-        book_name: bookName,
-      };
-      user.history.ratings.push(bookRating);
-    }
-
-    if (bookRating.rating !== rating) {
-      bookRating.rating = rating;
-      bookRating.date = new Date();
-    }
-
-    user.history.ratings.sort((a, b) => {
-      if (typeof a.date === 'string') {
-        a.date = new Date(a.date);
-      }
-      if (typeof b.date === 'string') {
-        b.date = new Date(b.date);
-      }
-      if (a.date.getTime() < b.date.getTime()) {
-        return -1;
-      } else {
-        return 1;
-      }
-    });
-
+  async addRatingBook(userIn: User, book_id: number, bookName: string, rating: number): Promise<void> {
     try {
+      const user = await this.findById(userIn.id);
+      if (!user.history.ratings) {
+        user.history.ratings = [];
+      }
+      let bookRating = user.history.ratings.find((br) => {
+        return br.book_id === book_id;
+      });
+      if (!bookRating) {
+        bookRating = {
+          book_id: book_id,
+          rating: undefined,
+          date: undefined,
+          book_name: bookName,
+        };
+        user.history.ratings.push(bookRating);
+      }
+
+      if (bookRating.rating !== rating) {
+        bookRating.rating = rating;
+        bookRating.date = new Date();
+      }
+
+      user.history.ratings.sort((a, b) => {
+        if (typeof a.date === 'string') {
+          a.date = new Date(a.date);
+        }
+        if (typeof b.date === 'string') {
+          b.date = new Date(b.date);
+        }
+        if (a.date.getTime() < b.date.getTime()) {
+          return -1;
+        } else {
+          return 1;
+        }
+      });
+
       await this.saveUser(user);
     } catch (reason) {
       this.logger.error(reason);


### PR DESCRIPTION
## Summary

- **Fix**: `addRatingBook()` and `updateLastConnection()` now reload the user from MongoDB before modifying and saving, preventing stale JWT data from overwriting download history via `replaceOne()`
- **Root cause**: The JWT token excludes `downloadedBooks` and `ratings` (deleted in `createToken()`). When these methods saved the JWT's stale user object, all download history was erased. On cache refresh (every 10 min), book download counts dropped to zero.
- **Pattern**: Follows the same safe pattern already used by `addDownloadedBook()` which calls `findById()` before modification

## Fichiers modifiés

| Fichier | Modification |
|---|---|
| `apps/api/src/app/users/users.service.ts` | `addRatingBook()` et `updateLastConnection()` rechargent le user depuis la DB |
| `apps/api/src/app/users/users.service.spec.ts` | Tests mis à jour pour vérifier le rechargement depuis la DB |

## Test plan

- [x] Tests unitaires backend (231 tests verts)
- [x] Tests unitaires frontend (260 tests verts)
- [x] Vérification manuelle : backend + frontend démarrent correctement
- [ ] Test fonctionnel : télécharger un livre → noter un livre → vérifier que le compteur ne tombe pas à zéro

Closes #139