### PR TITLE
fix: include series name in downloaded file title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.12.3](https://github.com/bibulle/myCalibreServer/compare/v0.12.2...v0.12.3) (2026-03-05)
+
+
+### Bug Fixes
+
+* include series name in downloaded file title ([#36](https://github.com/bibulle/myCalibreServer/issues/36)) ([dcb0f22](https://github.com/bibulle/myCalibreServer/commit/dcb0f22ba87f0074bec98d80215aee8ec6d6c64d))
+* reload user from DB before save in addRatingBook and updateLastConnection ([ffca081](https://github.com/bibulle/myCalibreServer/commit/ffca08116c2e630b2af115f7c3bd238321efd8e6)), closes [#139](https://github.com/bibulle/myCalibreServer/issues/139)
+
 ### [0.12.2](https://github.com/bibulle/myCalibreServer/compare/v0.12.1...v0.12.2) (2026-03-05)
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,60 @@ Ne demander de tester que lorsque les environnements sont fonctionnels et stable
 
 ---
 
+## Lancement dans un worktree (IMPORTANT)
+
+Lorsque l'on travaille dans un worktree (`.claude/worktrees/`), les données non versionnées (`.env`, `data/`, `node_modules/`) ne sont pas présentes. Avant de lancer les serveurs :
+
+1. **Installer les dépendances** :
+   ```bash
+   npm ci
+   ```
+
+2. **Copier le fichier `.env`** depuis le repo principal :
+   ```bash
+   cp /Users/m341772/Developer/myCalibreServer/.env .env
+   ```
+
+3. **Créer un symlink vers le répertoire `data/`** (bibliothèque Calibre + cache) :
+   ```bash
+   ln -s /Users/m341772/Developer/myCalibreServer/data data
+   ```
+   > Cela permet à l'API de trouver `metadata.db`, les couvertures et les fichiers EPUB/MOBI
+   > sans modifier le `.env`. Les chemins par défaut (`PATH_BOOKS`, `PATH_MY_CALIBRE`)
+   > résolvent vers `data/calibre` et `data/my-calibre` relatifs au CWD.
+
+4. **Libérer les ports** si nécessaire (un autre serveur peut déjà tourner) :
+   ```bash
+   lsof -ti:3333 | xargs kill -9 2>/dev/null   # API
+   lsof -ti:4200 | xargs kill -9 2>/dev/null   # Frontend
+   ```
+
+5. **Lancer les serveurs** :
+   ```bash
+   npm run start:api
+   npm run start:frontend
+   ```
+
+6. **Vérifier que les serveurs répondent** :
+   ```bash
+   curl -s http://localhost:3333/api/version   # API
+   curl -s http://localhost:4200 | head -1     # Frontend
+   ```
+
+### Variables d'environnement minimales requises
+
+| Variable | Obligatoire | Effet si absente |
+|---|---|---|
+| `SESSION_SECRET` | **Oui** | Le serveur quitte immédiatement (`process.exit(1)`) |
+| `AUTHENT_JWT_SECRET` | **Oui** | Toutes les routes authentifiées échouent |
+| `AUTHENT_LENGTH` | **Oui** | Le login crash (`pbkdf2Sync`) |
+| `AUTHENT_DIGEST` | **Oui** | Le login crash (`pbkdf2Sync`) |
+| `MONGO_URL` | Recommandé | Défaut : `mongodb://192.168.0.126:30994` |
+| `PATH_BOOKS` | Optionnel | Défaut : `data/calibre` (relatif au CWD, couvert par le symlink) |
+| `PATH_MY_CALIBRE` | Optionnel | Défaut : `data/my-calibre` (relatif au CWD, couvert par le symlink) |
+
+---
+
 ## Commandes de référence
 
 **Démarrage :**

--- a/apps/api/src/app/books/books.service.spec.ts
+++ b/apps/api/src/app/books/books.service.spec.ts
@@ -5,7 +5,9 @@ import { UsersService } from '../users/users.service';
 import { ConfigService } from '@nestjs/config';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { SeriesService } from '../series/series.service';
-import { Book } from '@my-calibre-server/api-interfaces';
+import { Book, BookData } from '@my-calibre-server/api-interfaces';
+import { HttpException } from '@nestjs/common';
+import { promises as fsPromises } from 'fs';
 
 describe('BooksService', () => {
   let service: BooksService;
@@ -16,11 +18,14 @@ describe('BooksService', () => {
   const mockCalibreDbService = {
     getBooks: jest.fn(),
     getBookById: jest.fn(),
+    getBookPaths: jest.fn(),
   };
 
   const mockUsersService = {
     findOne: jest.fn(),
     updateDownloads: jest.fn(),
+    checkToken: jest.fn(),
+    addDownloadedBook: jest.fn(),
   };
 
   const mockConfigService = {
@@ -207,17 +212,11 @@ describe('BooksService', () => {
 
   describe('Cron job initialization', () => {
     it('should register cron job on service creation', () => {
-      expect(mockSchedulerRegistry.addCronJob).toHaveBeenCalledWith(
-        'cronThumbnailRecurrent',
-        expect.any(Object)
-      );
+      expect(mockSchedulerRegistry.addCronJob).toHaveBeenCalledWith('cronThumbnailRecurrent', expect.any(Object));
     });
 
     it('should use configured cron expression', () => {
-      expect(mockConfigService.get).toHaveBeenCalledWith(
-        'CRON_Thumbnail_RECURRING',
-        expect.any(String)
-      );
+      expect(mockConfigService.get).toHaveBeenCalledWith('CRON_Thumbnail_RECURRING', expect.any(String));
     });
   });
 
@@ -286,6 +285,107 @@ describe('BooksService', () => {
 
       expect(book.data).toBeDefined();
       expect(book.data.length).toBe(0);
+    });
+  });
+
+  describe('getBookToDownload', () => {
+    let mockRes: any;
+
+    beforeEach(() => {
+      mockRes = {
+        set: jest.fn(),
+      };
+    });
+
+    it('should include series name in filename when book has a series', async () => {
+      const mockUser = { id: 1, username: 'testuser' };
+      mockCalibreDbService.getBookPaths.mockResolvedValue({
+        book_id: 1,
+        book_path: 'Author/Book Title (1)',
+        book_has_cover: '1',
+        series_name: 'My Series',
+        book_series_index: 3,
+        data: [new BookData({ data_id: 1, data_format: 'EPUB', data_size: 1000, data_name: 'Book_Title' })],
+      });
+      mockUsersService.checkToken.mockResolvedValue(mockUser);
+      mockUsersService.addDownloadedBook.mockResolvedValue(undefined);
+      jest.spyOn(fsPromises, 'stat').mockResolvedValue({} as any);
+
+      try {
+        await service.getBookToDownload('valid-token', 1, mockRes, 'EPUB', 'application/epub+zip');
+      } catch {
+        // StreamableFile may throw because there's no real file
+      }
+
+      expect(mockRes.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'Content-Disposition': 'attachment; filename="My Series - 3 - Book_Title.epub"',
+        })
+      );
+    });
+
+    it('should use only data_name in filename when book has no series', async () => {
+      const mockUser = { id: 1, username: 'testuser' };
+      mockCalibreDbService.getBookPaths.mockResolvedValue({
+        book_id: 2,
+        book_path: 'Author/Book Without Series (2)',
+        book_has_cover: '1',
+        series_name: '',
+        book_series_index: 0,
+        data: [new BookData({ data_id: 2, data_format: 'MOBI', data_size: 2000, data_name: 'Standalone_Book' })],
+      });
+      mockUsersService.checkToken.mockResolvedValue(mockUser);
+      mockUsersService.addDownloadedBook.mockResolvedValue(undefined);
+      jest.spyOn(fsPromises, 'stat').mockResolvedValue({} as any);
+
+      try {
+        await service.getBookToDownload('valid-token', 2, mockRes, 'MOBI', 'application/x-mobipocket-ebook');
+      } catch {
+        // StreamableFile may throw because there's no real file
+      }
+
+      expect(mockRes.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'Content-Disposition': 'attachment; filename="Standalone_Book.mobi"',
+        })
+      );
+    });
+
+    it('should sanitize special characters in series name', async () => {
+      const mockUser = { id: 1, username: 'testuser' };
+      mockCalibreDbService.getBookPaths.mockResolvedValue({
+        book_id: 3,
+        book_path: 'Author/Book (3)',
+        book_has_cover: '1',
+        series_name: 'Series: "Special" <Edition>',
+        book_series_index: 1,
+        data: [new BookData({ data_id: 3, data_format: 'EPUB', data_size: 1500, data_name: 'Special_Book' })],
+      });
+      mockUsersService.checkToken.mockResolvedValue(mockUser);
+      mockUsersService.addDownloadedBook.mockResolvedValue(undefined);
+      jest.spyOn(fsPromises, 'stat').mockResolvedValue({} as any);
+
+      try {
+        await service.getBookToDownload('valid-token', 3, mockRes, 'EPUB', 'application/epub+zip');
+      } catch {
+        // StreamableFile may throw because there's no real file
+      }
+
+      expect(mockRes.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'Content-Disposition': 'attachment; filename="Series_ _Special_ _Edition_ - 1 - Special_Book.epub"',
+        })
+      );
+    });
+
+    it('should throw INTERNAL_SERVER_ERROR when no token is provided', async () => {
+      await expect(service.getBookToDownload('', 1, mockRes, 'EPUB', 'application/epub+zip')).rejects.toThrow(HttpException);
+    });
+
+    it('should throw INTERNAL_SERVER_ERROR when token is invalid', async () => {
+      mockUsersService.checkToken.mockResolvedValue(null);
+
+      await expect(service.getBookToDownload('invalid-token', 1, mockRes, 'EPUB', 'application/epub+zip')).rejects.toThrow(HttpException);
     });
   });
 });

--- a/apps/api/src/app/books/books.service.ts
+++ b/apps/api/src/app/books/books.service.ts
@@ -162,10 +162,17 @@ export class BooksService {
             try {
               await fsPromises.stat(fullPath);
               await this._usersService.addDownloadedBook(user, book_id, data[0]);
+
+              let filename = data[0].data_name;
+              if (book.series_name) {
+                filename = `${book.series_name} - ${book.book_series_index} - ${filename}`;
+              }
+              filename = filename.replace(/[<>:"/\\|?*]/g, '_');
+
               res.set({
                 'Content-Type': contentType,
                 'Thumbnail-control': 'public, max-age=31536000',
-                'Content-Disposition': `attachment; filename="${data[0].data_name}.${format.toLowerCase()}"`,
+                'Content-Disposition': `attachment; filename="${filename}.${format.toLowerCase()}"`,
               });
               return new StreamableFile(createReadStream(fullPath));
             } catch (reason) {

--- a/apps/api/src/app/database/calibre-db1.service.ts
+++ b/apps/api/src/app/database/calibre-db1.service.ts
@@ -189,6 +189,10 @@ export class CalibreDb1Service {
         .field('books.id', 'book_id')
         .field('books.has_cover', 'book_has_cover')
         .field('books.path', 'book_path')
+        .field('books.series_index', 'book_series_index')
+
+        // sunSeries
+        .field(this._concat('series', 'book', 'name'), 'series_name')
 
         // sumData
         .field(this._concat_simple('data', 'books', 'book', 'id'), 'data_id')

--- a/libs/api-interfaces/src/lib/book.ts
+++ b/libs/api-interfaces/src/lib/book.ts
@@ -53,6 +53,8 @@ export class BookPath {
   book_id = 0;
   book_has_cover = '';
   book_path = '';
+  series_name = '';
+  book_series_index = 0;
 
   data: BookData[] = [];
 }

--- a/libs/api-interfaces/src/lib/version.json
+++ b/libs/api-interfaces/src/lib/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.12.2",
+  "version": "0.12.3",
   "github_url": "https://github.com/bibulle/myCalibreServer",
   "name": "my-calibre-server",
   "copyright": "2016-2026 Bibulle"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "my-calibre-server",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "my-calibre-server",
-      "version": "0.12.2",
+      "version": "0.12.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-calibre-server",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Closes #36

- When downloading a book that belongs to a series, the filename now includes the series name and index (e.g. `My Series - 3 - Book_Title.epub`)
- Books without a series keep the original filename (`Book_Title.epub`)
- Special characters in series names are sanitized for filesystem safety

## Changes

| File | Description |
|---|---|
| `libs/api-interfaces/src/lib/book.ts` | Added `series_name` and `book_series_index` to `BookPath` class |
| `apps/api/src/app/database/calibre-db1.service.ts` | Extended `getBookPaths()` SQL query with series fields |
| `apps/api/src/app/books/books.service.ts` | Build filename with series prefix + sanitize special chars |
| `apps/api/src/app/books/books.service.spec.ts` | 5 new tests for download filename logic |
| `CLAUDE.md` | Document worktree server launch procedure |

## Test plan

- [x] API unit tests pass (236 tests)
- [x] Frontend unit tests pass (260 tests)
- [ ] Manual: download a book belonging to a series → filename includes series name and index
- [ ] Manual: download a book without a series → filename unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)