### PR TITLE
fix: limit DockerHub push and DevOps config to master branch

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Checkout gitops
         uses: actions/checkout@v4
-        if: ${{ env.actions_token != '' }}
+        if: ${{ env.actions_token != '' && github.ref == 'refs/heads/master' }}
         with:
           repository: bibulle/myKubernetesConfig
           token: ${{ env.actions_token }}
@@ -85,12 +85,12 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ${{env.APP_PATH}}
-          push: ${{ env.dockerhub_username != '' && env.dockerhub_password != '' }}
+          push: ${{ env.dockerhub_username != '' && env.dockerhub_password != '' && github.ref == 'refs/heads/master' }}
           tags: ${{env.DOCKER_TAGS}}
 
       - name: Update k8s yaml file
         id: update_yml
-        if: ${{ env.actions_token != '' }}
+        if: ${{ env.actions_token != '' && github.ref == 'refs/heads/master' }}
         run: |
           cd ${{env.OPS_PATH}}
           image="bibulle\/${{env.APP_NAME}}"
@@ -100,7 +100,7 @@ jobs:
 
       - name: Commit k8s yaml file
         id: commit_yml
-        if: env.actions_token != '' && steps.update_yml.outputs.line_modified != '0'
+        if: env.actions_token != '' && github.ref == 'refs/heads/master' && steps.update_yml.outputs.line_modified != '0'
         run: |
           cd ${{env.OPS_PATH}}
           git config --global user.email "${GITHUB_ACTOR}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.12.6](https://github.com/bibulle/myCalibreServer/compare/v0.12.5...v0.12.6) (2026-03-06)
+
+
+### Bug Fixes
+
+* limit DockerHub push and DevOps config editing to master branch ([#150](https://github.com/bibulle/myCalibreServer/issues/150)) ([9bfd064](https://github.com/bibulle/myCalibreServer/commit/9bfd0648607b734f32d5ad780fdccb38fbdf35c7))
+
 ### [0.12.5](https://github.com/bibulle/myCalibreServer/compare/v0.12.4...v0.12.5) (2026-03-06)
 
 

--- a/libs/api-interfaces/src/lib/version.json
+++ b/libs/api-interfaces/src/lib/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.12.5",
+  "version": "0.12.6",
   "github_url": "https://github.com/bibulle/myCalibreServer",
   "name": "my-calibre-server",
   "copyright": "2016-2026 Bibulle"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "my-calibre-server",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "my-calibre-server",
-      "version": "0.12.5",
+      "version": "0.12.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-calibre-server",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary\n\nCloses #150\n\n- Conditionne le push Docker vers DockerHub à la branche `master` uniquement (`github.ref == 'refs/heads/master'`)\n- Conditionne le checkout du repo gitops, la mise à jour et le commit du fichier k8s à la branche `master` uniquement\n- Le build Docker et les autres étapes continuent de s'exécuter sur toutes les branches et PRs\n\n## Modifications\n\n| Étape | Changement |\n|---|---|\n| Checkout gitops | Ajout condition `master` |\n| Build and push | `push` conditionné à `master` |\n| Update k8s yaml | Ajout condition `master` |\n| Commit k8s yaml | Ajout condition `master` |\n\n## Test plan\n\n- [ ] Vérifier que le workflow CI se déclenche sur la PR (build uniquement, pas de push Docker)\n- [ ] Vérifier que le push DockerHub ne s'exécute que sur merge dans `master`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"