### PR TITLE
fix: switch GitHub MCP server to official Docker-based server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,7 @@ Thumbs.db
 # Nx cache
 .nx
 /.claude/worktrees
+/.claude/.env
+/.claude/settings.local.json
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md

--- a/.mcp.json
+++ b/.mcp.json
@@ -11,7 +11,7 @@
     "github": {
       "type": "stdio",
       "command": "/bin/bash",
-      "args": ["-c", "set -a && source ~/.claude/.env && set +a && npx -y @modelcontextprotocol/server-github"]
+      "args": ["-c", "set -a && source /Users/eric/.claude/.env && set +a && exec docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN ghcr.io/github/github-mcp-server"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Le serveur MCP GitHub configuré (`@modelcontextprotocol/server-github`) est déprécié par son auteur, et manquait de toute façon son fichier de token (`~/.claude/.env` n'existait pas).
- Remplacé par le serveur officiel `ghcr.io/github/github-mcp-server`, lancé via Docker avec un simple PAT — plus fiable que le pont OAuth distant (`mcp-remote`) testé en premier lieu, qui échouait de façon incohérente une fois spawné en sous-processus par le harness.
- `.claude/.env` et `.claude/settings.local.json` ajoutés au `.gitignore` pour éviter tout risque de fuite de token/secrets locaux.

## Test plan
- [x] Token vérifié directement contre l'API GitHub (`/user`, GraphQL) — valide, accès complet au repo
- [x] Serveur Docker testé manuellement en JSON-RPC (`initialize` + `tools/call list_pull_requests`) — réponse correcte
- [x] Testé en conditions réelles dans Claude Code après redémarrage : `get_me` retourne bien `bibulle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)