### PR TITLE
test: raise frontend/backend coverage and fix tooling gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.12.8](https://github.com/bibulle/myCalibreServer/compare/v0.12.7...v0.12.8) (2026-07-04)
+
+
+### Tests
+
+* raise frontend/backend coverage and fix tooling gaps ([8020511](https://github.com/bibulle/myCalibreServer/commit/80205117cb8e4c1d846d17a5292ba7f2b2d7d8fb))
+
 ### [0.12.7](https://github.com/bibulle/myCalibreServer/compare/v0.12.6...v0.12.7) (2026-07-04)
 
 

--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ npx nx e2e frontend-e2e --spec="apps/frontend-e2e/src/integration/app.spec.ts"
 ### Running Tests in CI/CD
 
 ```bash
-# Run all tests
+# Run all tests (frontend + backend)
 npm run test
 
-# Run tests with coverage
-npx nx test api --coverage
+# Run all tests with a coverage report (frontend + backend)
+npm run test:coverage
 ```
 

--- a/apps/api/src/app/authentication/authentication.controller.spec.ts
+++ b/apps/api/src/app/authentication/authentication.controller.spec.ts
@@ -191,6 +191,32 @@ describe('AuthenticationController', () => {
         status: HttpStatus.BAD_REQUEST,
       });
     });
+
+    it('should throw NotFound when the admin targets a user that does not exist', async () => {
+      const req = { user: mockAdminUser };
+      mockUsersService.findById.mockResolvedValue(null);
+
+      await expect(controller.googleUnlink(req, 'unknown-user-id')).rejects.toMatchObject({
+        status: HttpStatus.NOT_FOUND,
+      });
+    });
+
+    it('should wrap an unexpected lookup error into NotFound', async () => {
+      const req = { user: mockAdminUser };
+      mockUsersService.findById.mockRejectedValue(new Error('db down'));
+
+      await expect(controller.googleUnlink(req, 'unknown-user-id')).rejects.toMatchObject({
+        status: HttpStatus.NOT_FOUND,
+      });
+    });
+
+    it('should throw InternalServerError when there is no user on the request', async () => {
+      const req = { user: undefined };
+
+      await expect(controller.googleUnlink(req, 'any-id')).rejects.toMatchObject({
+        status: HttpStatus.INTERNAL_SERVER_ERROR,
+      });
+    });
   });
 
   describe('facebookLogin', () => {
@@ -226,6 +252,23 @@ describe('AuthenticationController', () => {
         status: HttpStatus.INTERNAL_SERVER_ERROR,
       });
     });
+
+    it('should handle Facebook OAuth callback for an already connected user', async () => {
+      const req = { user: { ...mockUser, facebook: { id: 'fb-123' } } };
+      const connectedUser = { ...mockAdminUser, facebook: {} };
+      const token = 'jwt-token-fb-connected';
+
+      mockUsersService.getBearerUser.mockResolvedValue(connectedUser);
+      mockUsersService.saveUser.mockReturnValue(undefined);
+      mockUsersService.createToken.mockReturnValue(token);
+
+      const result = await controller.facebookjLoginCallback(req);
+
+      expect(connectedUser.facebook).toEqual(req.user.facebook);
+      expect(usersService.saveUser).toHaveBeenCalledWith(connectedUser);
+      expect(result.id_token).toBe(token);
+      expect(result.user).toBe(connectedUser);
+    });
   });
 
   describe('facebookUnlink', () => {
@@ -248,6 +291,46 @@ describe('AuthenticationController', () => {
 
       await expect(controller.facebookUnlink(req, '')).rejects.toMatchObject({
         status: HttpStatus.BAD_REQUEST,
+      });
+    });
+
+    it('should allow admin to unlink another user Facebook account', async () => {
+      const req = { user: mockAdminUser };
+      const targetUser = { ...mockUser, facebook: { id: 'fb-123' } };
+
+      mockUsersService.findById.mockResolvedValue(targetUser);
+      mockUsersService.saveUser.mockReturnValue(undefined);
+      mockUsersService.user2API.mockReturnValue({ id: targetUser.id });
+
+      const result = await controller.facebookUnlink(req, mockUser.id);
+
+      expect(targetUser.facebook).toEqual({});
+      expect(usersService.findById).toHaveBeenCalledWith(mockUser.id);
+      expect(result.user.id).toBe(mockUser.id);
+    });
+
+    it('should reject non-admin unlinking another user', async () => {
+      const req = { user: mockUser };
+
+      await expect(controller.facebookUnlink(req, 'other-user-id')).rejects.toMatchObject({
+        status: HttpStatus.UNAUTHORIZED,
+      });
+    });
+
+    it('should throw NotFound when the admin targets a user that does not exist', async () => {
+      const req = { user: mockAdminUser };
+      mockUsersService.findById.mockResolvedValue(null);
+
+      await expect(controller.facebookUnlink(req, 'unknown-user-id')).rejects.toMatchObject({
+        status: HttpStatus.NOT_FOUND,
+      });
+    });
+
+    it('should throw InternalServerError when there is no user on the request', async () => {
+      const req = { user: undefined };
+
+      await expect(controller.facebookUnlink(req, 'any-id')).rejects.toMatchObject({
+        status: HttpStatus.INTERNAL_SERVER_ERROR,
       });
     });
   });
@@ -290,6 +373,15 @@ describe('AuthenticationController', () => {
 
     it('should throw when user is undefined', async () => {
       const req = { user: undefined };
+
+      await expect(controller.getUser(req)).rejects.toMatchObject({
+        status: HttpStatus.UNAUTHORIZED,
+      });
+    });
+
+    it('should wrap a lookup failure into Unauthorized', async () => {
+      const req = { user: mockUser };
+      mockUsersService.findById.mockRejectedValue(new Error('db down'));
 
       await expect(controller.getUser(req)).rejects.toMatchObject({
         status: HttpStatus.UNAUTHORIZED,

--- a/apps/api/src/app/books/books.service.spec.ts
+++ b/apps/api/src/app/books/books.service.spec.ts
@@ -6,9 +6,13 @@ import { ConfigService } from '@nestjs/config';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { SeriesService } from '../series/series.service';
 import { Book, BookData } from '@my-calibre-server/api-interfaces';
-import { HttpException, HttpStatus } from '@nestjs/common';
+import { HttpStatus } from '@nestjs/common';
 import * as fs from 'fs';
 import { promises as fsPromises } from 'fs';
+import { mkdtempSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import * as sharp from 'sharp';
 
 describe('BooksService', () => {
   let service: BooksService;
@@ -83,6 +87,7 @@ describe('BooksService', () => {
   });
 
   afterEach(() => {
+    jest.restoreAllMocks();
     jest.clearAllMocks();
   });
 
@@ -185,10 +190,17 @@ describe('BooksService', () => {
       expect(date).toBe(0);
     });
 
-    it('should return timestamp if thumbnail file exists', () => {
-      // This test would require mocking fs.statSync
-      // For now, we just test the non-existent case
-      expect(true).toBe(true);
+    it('should return the file mtime (in ms) if the thumbnail file exists', () => {
+      const book = {
+        book_id: 1,
+        book_path: 'Author/Book Title (1)',
+      } as unknown as Book;
+      const mtimeMs = new Date('2023-06-01').getTime();
+      jest.spyOn(fs, 'statSync').mockReturnValue({ mtimeMs } as any);
+
+      const date = service.getThumbnailDate(book);
+
+      expect(date).toBe(mtimeMs);
     });
   });
 
@@ -205,10 +217,16 @@ describe('BooksService', () => {
       expect(date).toBe(0);
     });
 
-    it('should return timestamp if sprite file exists', () => {
-      // This test would require mocking fs.statSync
-      // For now, we just test the non-existent case
-      expect(true).toBe(true);
+    it('should return the file mtime (in ms) if the sprite file exists', () => {
+      const book = {
+        book_id: 1,
+      } as unknown as Book;
+      const mtimeMs = new Date('2023-06-01').getTime();
+      jest.spyOn(fs, 'statSync').mockReturnValue({ mtimeMs } as any);
+
+      const date = service.getSpriteDate(book);
+
+      expect(date).toBe(mtimeMs);
     });
   });
 
@@ -451,6 +469,299 @@ describe('BooksService', () => {
 
       await expect(service.getBookToDownload('valid-token', 1, mockRes, 'EPUB', 'application/epub+zip')).rejects.toMatchObject({
         status: HttpStatus.NOT_FOUND,
+      });
+    });
+
+    it('should throw NOT_FOUND when the book has no path or data', async () => {
+      mockCalibreDbService.getBookPaths.mockResolvedValue({ book_id: 1, book_path: '', data: undefined });
+      mockUsersService.checkToken.mockResolvedValue({ id: 1 });
+
+      await expect(service.getBookToDownload('valid-token', 1, mockRes, 'EPUB', 'application/epub+zip')).rejects.toMatchObject({
+        status: HttpStatus.NOT_FOUND,
+      });
+    });
+
+    it('should throw NOT_FOUND when no data matches the requested format', async () => {
+      mockCalibreDbService.getBookPaths.mockResolvedValue({
+        book_id: 1,
+        book_path: 'Author/Book Title (1)',
+        data: [new BookData({ data_id: 1, data_format: 'MOBI', data_size: 1000, data_name: 'Book_Title' })],
+      });
+      mockUsersService.checkToken.mockResolvedValue({ id: 1 });
+
+      await expect(service.getBookToDownload('valid-token', 1, mockRes, 'EPUB', 'application/epub+zip')).rejects.toMatchObject({
+        status: HttpStatus.NOT_FOUND,
+      });
+    });
+
+    it('should throw INTERNAL_SERVER_ERROR for an unexpected failure', async () => {
+      mockCalibreDbService.getBookPaths.mockResolvedValue({
+        book_id: 1,
+        book_path: 'Author/Book Title (1)',
+        data: [new BookData({ data_id: 1, data_format: 'EPUB', data_size: 1000, data_name: 'Book_Title' })],
+      });
+      mockUsersService.checkToken.mockResolvedValue({ id: 1 });
+      jest.spyOn(fsPromises, 'stat').mockRejectedValue(new Error('disk exploded'));
+
+      await expect(service.getBookToDownload('valid-token', 1, mockRes, 'EPUB', 'application/epub+zip')).rejects.toMatchObject({
+        status: HttpStatus.INTERNAL_SERVER_ERROR,
+      });
+    });
+  });
+
+  describe('calculateMissingBookThumbnail', () => {
+    it('should regenerate the thumbnail when the cover is newer than the existing thumbnail', async () => {
+      const book = { book_id: 1, book_has_cover: '1', book_path: 'Author/Book (1)', book_title: 'Book' } as unknown as Book;
+      mockCalibreDbService.getBooks.mockResolvedValue([book]);
+      jest.spyOn(fs, 'statSync').mockImplementation((p: any) => {
+        if (String(p).includes('cover.jpg')) {
+          return { mtime: new Date(2023, 0, 2) } as any;
+        }
+        return { mtime: new Date(2023, 0, 1) } as any;
+      });
+      jest.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined);
+      const resizeImageSpy = jest.spyOn(service, 'resizeImage').mockResolvedValue(undefined);
+
+      await service.calculateMissingBookThumbnail();
+
+      expect(resizeImageSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should skip books without a cover', async () => {
+      const book = { book_id: 1, book_has_cover: '', book_path: 'Author/Book (1)' } as unknown as Book;
+      mockCalibreDbService.getBooks.mockResolvedValue([book]);
+      const resizeImageSpy = jest.spyOn(service, 'resizeImage').mockResolvedValue(undefined);
+
+      await service.calculateMissingBookThumbnail();
+
+      expect(resizeImageSpy).not.toHaveBeenCalled();
+    });
+
+    it('should skip a book whose thumbnail is already up to date', async () => {
+      const book = { book_id: 1, book_has_cover: '1', book_path: 'Author/Book (1)' } as unknown as Book;
+      mockCalibreDbService.getBooks.mockResolvedValue([book]);
+      jest.spyOn(fs, 'statSync').mockImplementation((p: any) => {
+        if (String(p).includes('cover.jpg')) {
+          return { mtime: new Date(2023, 0, 1) } as any;
+        }
+        return { mtime: new Date(2023, 0, 2) } as any;
+      });
+      const resizeImageSpy = jest.spyOn(service, 'resizeImage').mockResolvedValue(undefined);
+
+      await service.calculateMissingBookThumbnail();
+
+      expect(resizeImageSpy).not.toHaveBeenCalled();
+    });
+
+    it('should log and rethrow when the database call fails', async () => {
+      mockCalibreDbService.getBooks.mockRejectedValue(new Error('db down'));
+
+      await expect(service.calculateMissingBookThumbnail()).rejects.toThrow('db down');
+    });
+  });
+
+  describe('calculateSpritesBookThumbnail', () => {
+    it('should build one sprite sheet per group of books that needs regeneration', async () => {
+      const books = [
+        { book_id: 1 },
+        { book_id: 2 },
+        { book_id: 60 }, // falls in a different sprite group (SPRITES_SIZE = 50)
+      ] as unknown as Book[];
+      mockCalibreDbService.getBooks.mockResolvedValue(books);
+      // thumbnail newer than sprite => needs (re)generation for every book here
+      jest.spyOn(service, 'getSpriteDate').mockReturnValue(0);
+      jest.spyOn(service, 'getThumbnailDate').mockReturnValue(1);
+      const createSpritesBooksSpy = jest.spyOn(service, 'createSpritesBooks').mockResolvedValue(undefined);
+
+      await service.calculateSpritesBookThumbnail();
+
+      expect(createSpritesBooksSpy).toHaveBeenCalledTimes(2);
+      expect(createSpritesBooksSpy.mock.calls.map((c) => c[0]).sort((a, b) => a - b)).toEqual([0, 50]);
+    });
+
+    it('should skip a sprite group that is already up to date', async () => {
+      const books = [{ book_id: 1 }] as unknown as Book[];
+      mockCalibreDbService.getBooks.mockResolvedValue(books);
+      jest.spyOn(service, 'getSpriteDate').mockReturnValue(2);
+      jest.spyOn(service, 'getThumbnailDate').mockReturnValue(1);
+      const createSpritesBooksSpy = jest.spyOn(service, 'createSpritesBooks').mockResolvedValue(undefined);
+
+      await service.calculateSpritesBookThumbnail();
+
+      expect(createSpritesBooksSpy).not.toHaveBeenCalled();
+    });
+
+    it('should log and rethrow when the database call fails', async () => {
+      mockCalibreDbService.getBooks.mockRejectedValue(new Error('db down'));
+
+      await expect(service.calculateSpritesBookThumbnail()).rejects.toThrow('db down');
+    });
+  });
+
+  describe('Image processing (real sharp)', () => {
+    let tmpDir: string;
+    let srcImagePath: string;
+
+    beforeEach(async () => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'books-service-test-'));
+      srcImagePath = join(tmpDir, 'source.jpg');
+      await sharp({ create: { width: 100, height: 200, channels: 3, background: { r: 255, g: 0, b: 0 } } })
+        .jpeg()
+        .toFile(srcImagePath);
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    describe('resizeImage', () => {
+      it('should resize the source image to the thumbnail height and write it to disk', async () => {
+        const trgPath = join(tmpDir, 'nested', 'thumbnail.jpg');
+
+        await service.resizeImage(srcImagePath, trgPath);
+
+        expect(existsSync(trgPath)).toBe(true);
+        const meta = await sharp(trgPath).metadata();
+        expect(meta.height).toBe(160);
+      });
+
+      it('should log and rethrow when the source image cannot be read', async () => {
+        await expect(service.resizeImage(join(tmpDir, 'missing.jpg'), join(tmpDir, 'out.jpg'))).rejects.toBeDefined();
+      });
+    });
+
+    describe('saveBufferToPng', () => {
+      it('should write the buffer as a resized PNG file', async () => {
+        const buffer = await sharp(srcImagePath).png().toBuffer();
+        const trgPath = join(tmpDir, 'series.png');
+
+        await service.saveBufferToPng(buffer, trgPath);
+
+        expect(existsSync(trgPath)).toBe(true);
+        const meta = await sharp(trgPath).metadata();
+        expect(meta.format).toBe('png');
+        expect(meta.height).toBe(160);
+      });
+    });
+
+    describe('getThumbnailInfo', () => {
+      it('should return sharp output info for a given image', async () => {
+        const info = await BooksService.getThumbnailInfo(srcImagePath);
+
+        expect(info.height).toBe(160);
+      });
+
+      it('should reject when the image cannot be read', async () => {
+        await expect(BooksService.getThumbnailInfo(join(tmpDir, 'missing.jpg'))).rejects.toBeDefined();
+      });
+    });
+
+    describe('resizeSeries', () => {
+      it('should initialize the buffer from the first cover', async () => {
+        const calculation = { theBuffer: undefined, width: 0, height: 160, step_increment: 10, step: -10 } as any;
+
+        await service.resizeSeries(srcImagePath, calculation);
+
+        expect(calculation.theBuffer).toBeDefined();
+        expect(calculation.width).toBeGreaterThan(0);
+      });
+
+      it('should composite a second cover onto the existing buffer', async () => {
+        // Mirrors the step/height progression used by calculateMissingSeriesThumbnail,
+        // which is what keeps the composited overlay within the canvas bounds.
+        const calculation = { theBuffer: undefined, width: 0, height: 160, step_increment: 10, step: -10 } as any;
+        calculation.step += calculation.step_increment;
+        calculation.height += calculation.step;
+        await service.resizeSeries(srcImagePath, calculation);
+        const previousBuffer = calculation.theBuffer;
+
+        calculation.step += calculation.step_increment;
+        calculation.height += calculation.step;
+        await service.resizeSeries(srcImagePath, calculation);
+
+        expect(calculation.theBuffer).toBeDefined();
+        expect(calculation.theBuffer).not.toBe(previousBuffer);
+      });
+
+      it('should shrink the buffer back down once it grows past the size limit', async () => {
+        const calculation = { theBuffer: undefined, width: 0, height: 2000, step_increment: 10, step: -10 } as any;
+        calculation.step += calculation.step_increment;
+        await service.resizeSeries(srcImagePath, calculation);
+
+        calculation.step += calculation.step_increment;
+        calculation.height += calculation.step;
+        await service.resizeSeries(srcImagePath, calculation);
+
+        expect(calculation.height).toBeLessThan(2000);
+      });
+
+      it('should log and rethrow when the source image cannot be read', async () => {
+        const calculation = { theBuffer: undefined, width: 0, height: 160, step_increment: 10, step: -10 } as any;
+
+        await expect(service.resizeSeries(join(tmpDir, 'missing.jpg'), calculation)).rejects.toBeDefined();
+      });
+    });
+
+    describe('getSpritesBooksOverlay / createSpritesBooks', () => {
+      it('should build one overlay entry per book in the sprite group, using the error cover when no thumbnail exists', async () => {
+        const books = [{ book_id: 0 }, { book_id: 1 }] as unknown as Book[];
+        mockCalibreDbService.getBooks.mockResolvedValue(books);
+        jest.spyOn(BooksService, 'getThumbnailInfo').mockResolvedValue({ width: 100 } as any);
+        jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+        const overlay = await service.getSpritesBooksOverlay(0);
+
+        expect(overlay).toHaveLength(2);
+        // each slot is one THUMBNAIL_HEIGHT (160px) apart, centered horizontally within its slot
+        expect(overlay[1].left - overlay[0].left).toBe(160);
+      });
+
+      it('should use the real thumbnail path when one exists on disk', async () => {
+        const books = [{ book_id: 1 }] as unknown as Book[];
+        mockCalibreDbService.getBooks.mockResolvedValue(books);
+        jest.spyOn(BooksService, 'getThumbnailInfo').mockResolvedValue({ width: 120 } as any);
+        jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+        const overlay = await service.getSpritesBooksOverlay(0);
+
+        expect(overlay[0].input).toBe(service.getThumbnailPath(books[0]));
+      });
+
+      it('should fall back to the error cover info when reading the real thumbnail info fails', async () => {
+        const books = [{ book_id: 1 }] as unknown as Book[];
+        mockCalibreDbService.getBooks.mockResolvedValue(books);
+        jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+        jest
+          .spyOn(BooksService, 'getThumbnailInfo')
+          .mockResolvedValueOnce({ width: 90 } as any) // err_info
+          .mockRejectedValueOnce('broken thumbnail');
+
+        const overlay = await service.getSpritesBooksOverlay(0);
+
+        expect(overlay).toHaveLength(1);
+      });
+
+      it('should propagate errors from the database', async () => {
+        jest.spyOn(BooksService, 'getThumbnailInfo').mockResolvedValue({ width: 100 } as any);
+        mockCalibreDbService.getBooks.mockRejectedValue('db down');
+
+        await expect(service.getSpritesBooksOverlay(0)).rejects.toEqual('db down');
+      });
+
+      it('should assemble the sprite sheet and write it to disk', async () => {
+        const spritePath = join(tmpDir, 'sprites', 'sprites_000003.png');
+        jest.spyOn(service, 'getSpritesBooksOverlay').mockResolvedValue([]);
+        jest.spyOn(service, 'getSpritesPath').mockReturnValue(spritePath);
+
+        await service.createSpritesBooks(3);
+
+        expect(existsSync(spritePath)).toBe(true);
+      });
+
+      it('should log and rethrow when building the sprite sheet fails', async () => {
+        jest.spyOn(service, 'getSpritesBooksOverlay').mockRejectedValue(new Error('overlay failed'));
+
+        await expect(service.createSpritesBooks(3)).rejects.toThrow('overlay failed');
       });
     });
   });

--- a/apps/api/src/app/cache/cache.service.spec.ts
+++ b/apps/api/src/app/cache/cache.service.spec.ts
@@ -1,0 +1,267 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { CacheService, CacheKey } from './cache.service';
+import { CalibreDb1Service } from '../database/calibre-db1.service';
+import { UsersService } from '../users/users.service';
+
+describe('CacheService', () => {
+  let service: CacheService;
+  let tmpDir: string;
+
+  const mockCalibreDbService = {
+    getDbDate: jest.fn(),
+    getBooks: jest.fn(),
+    getAllAuthors: jest.fn(),
+    getAllSeries: jest.fn(),
+    getAllTags: jest.fn(),
+    getBooksCount: jest.fn(),
+    fillBooksFromUser: jest.fn(),
+  };
+
+  const mockUsersService = {
+    getAll: jest.fn(),
+  };
+
+  const mockSchedulerRegistry = {
+    addCronJob: jest.fn(),
+    getCronJob: jest.fn(),
+    deleteCronJob: jest.fn(),
+  };
+
+  let mockConfigService: { get: jest.Mock };
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'cache-service-test-'));
+
+    mockConfigService = {
+      get: jest.fn((key: string, defaultValue?: string) => {
+        if (key === 'PATH_MY_CALIBRE') {
+          return tmpDir;
+        }
+        return defaultValue;
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CacheService,
+        { provide: ConfigService, useValue: mockConfigService },
+        { provide: UsersService, useValue: mockUsersService },
+        { provide: CalibreDb1Service, useValue: mockCalibreDbService },
+        { provide: SchedulerRegistry, useValue: mockSchedulerRegistry },
+      ],
+    }).compile();
+
+    service = module.get<CacheService>(CacheService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should register the recurring cache renewal cron job on construction', () => {
+    expect(mockSchedulerRegistry.addCronJob).toHaveBeenCalledWith('cronCacheRecurrent', expect.any(Object));
+  });
+
+  describe('getCacheDate', () => {
+    it('should reject for an unknown cache key', async () => {
+      await expect(service.getCacheDate('not-a-key' as unknown as CacheKey)).rejects.toEqual("Cache not found : 'not-a-key'");
+    });
+
+    it('should reject when the cache file does not exist yet', async () => {
+      await expect(service.getCacheDate(CacheKey.BOOKS)).rejects.toEqual(`One cache not found : '${CacheKey.BOOKS}'`);
+    });
+
+    it('should resolve with the modification date of an existing cache file', async () => {
+      const cachePath = join(tmpDir, 'cache', `${CacheKey[CacheKey.BOOKS]}.json`);
+      mkdirSync(join(tmpDir, 'cache'), { recursive: true });
+      writeFileSync(cachePath, '[]');
+
+      const result = await service.getCacheDate(CacheKey.BOOKS);
+
+      expect(result).toEqual(statSync(cachePath).mtime);
+    });
+  });
+
+  describe('getCacheNumber', () => {
+    it('should reject for an unknown cache key', async () => {
+      await expect(service.getCacheNumber('not-a-key' as unknown as CacheKey)).rejects.toEqual("Cache not found : 'not-a-key'");
+    });
+
+    it('should reject when the cache file does not exist yet', async () => {
+      await expect(service.getCacheNumber(CacheKey.COUNT)).rejects.toEqual(`One cache not found : '${CacheKey.COUNT}'`);
+    });
+
+    it('should resolve with the numeric content of an existing cache file', async () => {
+      const cachePath = join(tmpDir, 'cache', `${CacheKey[CacheKey.COUNT]}.json`);
+      mkdirSync(join(tmpDir, 'cache'), { recursive: true });
+      writeFileSync(cachePath, '42');
+
+      const result = await service.getCacheNumber(CacheKey.COUNT);
+
+      expect(result).toEqual(42);
+    });
+  });
+
+  describe('getCachePath', () => {
+    it('should reject for an unknown cache key', async () => {
+      await expect(service.getCachePath('not-a-key' as unknown as CacheKey)).rejects.toEqual("Cache not found : 'not-a-key'");
+    });
+
+    it('should build and sort the books cache, then persist it to disk', async () => {
+      const books = [
+        { series_name: null, series_sort: '', book_series_index: 0, book_sort: 'Zebra' },
+        { series_name: null, series_sort: '', book_series_index: 0, book_sort: 'Alpha' },
+      ];
+      mockCalibreDbService.getBooks.mockResolvedValue(books);
+      mockUsersService.getAll.mockResolvedValue([]);
+      mockCalibreDbService.fillBooksFromUser.mockResolvedValue(books);
+
+      const cachePath = await service.getCachePath(CacheKey.BOOKS, new Date());
+
+      expect(mockCalibreDbService.getBooks).toHaveBeenCalled();
+      expect(mockCalibreDbService.fillBooksFromUser).toHaveBeenCalledWith(books, expect.any(Promise), true);
+      expect(existsSync(cachePath)).toBe(true);
+      const written = JSON.parse(readFileSync(cachePath, 'utf-8'));
+      expect(written.books).toEqual(books);
+    });
+
+    it('should build the new-books cache without sorting', async () => {
+      const books = [{ book_sort: 'Zebra' }, { book_sort: 'Alpha' }];
+      mockCalibreDbService.getBooks.mockResolvedValue(books);
+      mockUsersService.getAll.mockResolvedValue([]);
+      mockCalibreDbService.fillBooksFromUser.mockResolvedValue(books);
+
+      await service.getCachePath(CacheKey.NEW_BOOKS, new Date());
+
+      expect(mockCalibreDbService.getBooks).toHaveBeenCalledWith(200, 0);
+    });
+
+    it('should build and sort the authors cache', async () => {
+      const authors = [
+        { author_sort: 'Zebra', author_name: 'Zebra' },
+        { author_sort: 'Alpha', author_name: 'Alpha' },
+      ];
+      mockCalibreDbService.getAllAuthors.mockResolvedValue(authors);
+      mockUsersService.getAll.mockResolvedValue([]);
+      mockCalibreDbService.fillBooksFromUser.mockResolvedValue(authors);
+
+      const cachePath = await service.getCachePath(CacheKey.AUTHORS, new Date());
+
+      const written = JSON.parse(readFileSync(cachePath, 'utf-8'));
+      expect(written.authors.map((a: { author_sort: string }) => a.author_sort)).toEqual(['Alpha', 'Zebra']);
+    });
+
+    it('should build and sort the series cache', async () => {
+      const series = [{ series_sort: 'Zebra' }, { series_sort: 'Alpha' }];
+      mockCalibreDbService.getAllSeries.mockResolvedValue(series);
+      mockUsersService.getAll.mockResolvedValue([]);
+      mockCalibreDbService.fillBooksFromUser.mockResolvedValue(series);
+
+      const cachePath = await service.getCachePath(CacheKey.SERIES, new Date());
+
+      const written = JSON.parse(readFileSync(cachePath, 'utf-8'));
+      expect(written.series.map((s: { series_sort: string }) => s.series_sort)).toEqual(['Alpha', 'Zebra']);
+    });
+
+    it('should build and sort the tags cache', async () => {
+      const tags = [{ tag_name: 'Zebra' }, { tag_name: 'Alpha' }];
+      mockCalibreDbService.getAllTags.mockResolvedValue(tags);
+      mockUsersService.getAll.mockResolvedValue([]);
+      mockCalibreDbService.fillBooksFromUser.mockResolvedValue(tags);
+
+      const cachePath = await service.getCachePath(CacheKey.TAGS, new Date());
+
+      const written = JSON.parse(readFileSync(cachePath, 'utf-8'));
+      expect(written.tags.map((t: { tag_name: string }) => t.tag_name)).toEqual(['Alpha', 'Zebra']);
+    });
+
+    it('should persist a numeric result (count) without going through the array branch', async () => {
+      mockCalibreDbService.getBooksCount.mockResolvedValue(7);
+
+      const cachePath = await service.getCachePath(CacheKey.COUNT, new Date());
+
+      expect(readFileSync(cachePath, 'utf-8')).toEqual('7');
+      expect(mockCalibreDbService.fillBooksFromUser).not.toHaveBeenCalled();
+    });
+
+    it('should resolve immediately without recalculating when the cache is already fresher than dbDate', async () => {
+      mockCalibreDbService.getBooksCount.mockResolvedValue(1);
+      await service.getCachePath(CacheKey.COUNT, new Date(2024, 0, 1));
+      mockCalibreDbService.getBooksCount.mockClear();
+
+      const cachePath = await service.getCachePath(CacheKey.COUNT, new Date(1));
+
+      expect(mockCalibreDbService.getBooksCount).not.toHaveBeenCalled();
+      expect(cachePath).toContain(`${CacheKey[CacheKey.COUNT]}.json`);
+    });
+
+    it('should reject when the underlying database call fails', async () => {
+      mockCalibreDbService.getBooksCount.mockRejectedValue('db error');
+
+      await expect(service.getCachePath(CacheKey.COUNT, new Date())).rejects.toEqual('db error');
+    });
+
+    it('should reject when filling books from user fails', async () => {
+      mockCalibreDbService.getBooks.mockResolvedValue([{ book_sort: 'A' }]);
+      mockUsersService.getAll.mockResolvedValue([]);
+      mockCalibreDbService.fillBooksFromUser.mockRejectedValue('fill error');
+
+      await expect(service.getCachePath(CacheKey.BOOKS, new Date())).rejects.toEqual('fill error');
+    });
+  });
+
+  describe('renewCacheIfNeeded', () => {
+    it('should renew every cache table based on the current db date', async () => {
+      mockCalibreDbService.getDbDate.mockResolvedValue(new Date());
+      const getCachePathSpy = jest.spyOn(service, 'getCachePath').mockResolvedValue('/some/path');
+
+      service.renewCacheIfNeeded();
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(getCachePathSpy).toHaveBeenCalledTimes(6);
+    });
+
+    it('should log an error when renewal fails', async () => {
+      mockCalibreDbService.getDbDate.mockResolvedValue(new Date());
+      jest.spyOn(service, 'getCachePath').mockRejectedValue('boom');
+      const loggerErrorSpy = jest.spyOn((service as unknown as { logger: { error: jest.Mock } }).logger, 'error').mockImplementation(() => undefined);
+
+      service.renewCacheIfNeeded();
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(loggerErrorSpy).toHaveBeenCalledWith('boom');
+    });
+  });
+
+  describe('renewCacheForced', () => {
+    it('should renew every cache table using a far-future db date', async () => {
+      const getCachePathSpy = jest.spyOn(service, 'getCachePath').mockResolvedValue('/some/path');
+
+      service.renewCacheForced();
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(getCachePathSpy).toHaveBeenCalledTimes(6);
+      expect(getCachePathSpy.mock.calls[0][1]).toEqual(new Date(2100, 0, 1));
+    });
+
+    it('should log an error when forced renewal fails', async () => {
+      jest.spyOn(service, 'getCachePath').mockRejectedValue('boom');
+      const loggerErrorSpy = jest.spyOn((service as unknown as { logger: { error: jest.Mock } }).logger, 'error').mockImplementation(() => undefined);
+
+      service.renewCacheForced();
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(loggerErrorSpy).toHaveBeenCalledWith('boom');
+    });
+  });
+});

--- a/apps/api/src/app/database/calibre-db1.service.spec.ts
+++ b/apps/api/src/app/database/calibre-db1.service.spec.ts
@@ -2,15 +2,36 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { CalibreDb1Service } from './calibre-db1.service';
 import { ConfigService } from '@nestjs/config';
 import * as path from 'path';
+import { User } from '@my-calibre-server/api-interfaces';
 
-// Mock BooksService to avoid circular dependency
+// Mock BooksService to avoid a circular dependency (books.service.ts -> series.service.ts ->
+// calibre-db1.service.ts -> books.service.ts). `jest.requireActual` can't be used here since it
+// re-enters that same cycle. This mock replicates just enough of the real static row-mapping
+// (splitting pipe-delimited SQL fields into arrays, parsing dates) for getAllSeries/Authors/Tags
+// to exercise their real grouping/sorting logic against realistic Book shapes.
 jest.mock('../books/books.service', () => ({
   BooksService: {
-    createBook: jest.fn((data) => ({
-      ...data,
-      book_id: data.book_id || 1,
-      book_title: data.book_title || 'Test Book',
-    })),
+    createBook: (row: any) => {
+      const split = (name: string) => (row[name] && String(row[name]).length > 0 ? String(row[name]).split('|') : []);
+      const book = { ...row };
+      ['data_id', 'author_id', 'author_name', 'author_sort', 'tag_id', 'tag_name'].forEach((name) => {
+        book[name] = split(name);
+      });
+      ['book_date', 'timestamp', 'last_modified'].forEach((name) => {
+        book[name] = new Date(book[name]);
+      });
+      book.data = split('data_id').map((id: string, i: number) => ({
+        data_id: id,
+        data_format: split('data_format')[i],
+        data_size: split('data_size')[i],
+        data_name: split('data_name')[i],
+      }));
+      delete book['data_format'];
+      delete book['data_size'];
+      delete book['data_name'];
+      book.history = { ratings: [], downloads: [] };
+      return book;
+    },
   },
 }));
 
@@ -49,6 +70,7 @@ describe('CalibreDb1Service', () => {
   });
 
   afterEach(() => {
+    jest.restoreAllMocks();
     jest.clearAllMocks();
   });
 
@@ -73,6 +95,15 @@ describe('CalibreDb1Service', () => {
       expect(result).toBeDefined();
       // Just verify it returns something date-like
       expect(result.getTime).toBeDefined();
+    });
+
+    it('should reject when the database file cannot be stat-ed', async () => {
+      const originalDbFile = CalibreDb1Service['DB_FILE'];
+      CalibreDb1Service['DB_FILE'] = '/does/not/exist/metadata.db';
+
+      await expect(service.getDbDate()).rejects.toBeDefined();
+
+      CalibreDb1Service['DB_FILE'] = originalDbFile;
     });
   });
 
@@ -121,6 +152,12 @@ describe('CalibreDb1Service', () => {
         expect(result[0].book_id).toBe(2);
       }
     });
+
+    it('should reject when the underlying query fails', async () => {
+      jest.spyOn(service['_db'], 'all').mockImplementation(((query: string, cb: (err: unknown, rows?: unknown) => void) => cb(new Error('sql error'))) as any);
+
+      await expect(service.getBooks()).rejects.toThrow('sql error');
+    });
   });
 
   describe('getBooksCount', () => {
@@ -137,6 +174,12 @@ describe('CalibreDb1Service', () => {
 
       expect(result).toBeGreaterThan(0);
     });
+
+    it('should reject when the underlying query fails', async () => {
+      jest.spyOn(service['_db'], 'all').mockImplementation(((query: string, cb: (err: unknown, rows?: unknown) => void) => cb(new Error('sql error'))) as any);
+
+      await expect(service.getBooksCount()).rejects.toThrow('sql error');
+    });
   });
 
   describe('getBookPaths', () => {
@@ -145,6 +188,12 @@ describe('CalibreDb1Service', () => {
 
       expect(result).toBeDefined();
       expect(result.book_path).toBeDefined();
+    });
+
+    it('should reject when the underlying query fails', async () => {
+      jest.spyOn(service['_db'], 'get').mockImplementation(((query: string, cb: (err: unknown, row?: unknown) => void) => cb(new Error('sql error'))) as any);
+
+      await expect(service.getBookPaths(2)).rejects.toThrow('sql error');
     });
   });
 
@@ -156,50 +205,91 @@ describe('CalibreDb1Service', () => {
       expect(result.book_id).toBe(2);
       expect(result.book_title).toBeDefined();
     });
+
+    it('should reject when the book id does not exist', async () => {
+      await expect(service.getBook(999999, Promise.resolve([]))).rejects.toEqual('Not found');
+    });
+
+    it('should propagate errors from getBooks', async () => {
+      jest.spyOn(service, 'getBooks').mockRejectedValue(new Error('db down'));
+
+      await expect(service.getBook(2, Promise.resolve([]))).rejects.toThrow('db down');
+    });
   });
 
   describe('getAllSeries', () => {
-    it('should call getAllSeries and handle response', async () => {
-      // getAllSeries has complex transformation logic that requires proper BooksService mock
-      // The mock doesn't replicate the full transformation, so we expect it might fail
-      try {
-        const result = await service.getAllSeries();
-        // If it succeeds, verify it's defined
-        expect(result).toBeDefined();
-      } catch (error) {
-        // If it fails, verify it's because of the mock limitation
-        expect(error.message).toMatch(/getFullYear|forEach/);
+    it('should group books by series, sorted by series index', async () => {
+      const result = await service.getAllSeries();
+
+      expect(Array.isArray(result)).toBe(true);
+      for (const series of result) {
+        expect(series.books.length).toBeGreaterThan(0);
+        const indices = series.books.map((b) => b.book_series_index);
+        expect(indices).toEqual([...indices].sort((a, b) => a - b));
       }
+    });
+
+    it('should deduplicate author names/sorts and publication years within a series', async () => {
+      const result = await service.getAllSeries();
+      const seriesWithBooks = result.find((s) => s.books.length > 0);
+
+      if (seriesWithBooks) {
+        expect(new Set(seriesWithBooks.author_name).size).toBe(seriesWithBooks.author_name.length);
+        expect(new Set(seriesWithBooks.book_date.map((d) => d.getFullYear())).size).toBe(seriesWithBooks.book_date.length);
+      }
+    });
+
+    it('should propagate errors from getBooks', async () => {
+      jest.spyOn(service, 'getBooks').mockRejectedValue(new Error('db down'));
+
+      await expect(service.getAllSeries()).rejects.toThrow('db down');
     });
   });
 
   describe('getAllAuthors', () => {
-    it('should call getAllAuthors and handle response', async () => {
-      // getAllAuthors has complex transformation logic that requires proper BooksService mock
-      // The mock doesn't replicate the full transformation, so we expect it might fail
-      try {
-        const result = await service.getAllAuthors();
-        // If it succeeds, verify it's defined
-        expect(result).toBeDefined();
-      } catch (error) {
-        // If it fails, verify it's because of the mock limitation
-        expect(error.message).toMatch(/forEach/);
+    it('should group books by author', async () => {
+      const result = await service.getAllAuthors();
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBeGreaterThan(0);
+      for (const author of result) {
+        expect(author.books.length).toBeGreaterThan(0);
       }
+    });
+
+    it('should sort each author books by series (then index), then title', async () => {
+      const result = await service.getAllAuthors();
+      const authorWithMultipleBooks = result.find((a) => a.books.length > 1);
+
+      if (authorWithMultipleBooks) {
+        const sortKey = (b: (typeof authorWithMultipleBooks.books)[number]) =>
+          (b.series_sort == null ? '' : b.series_sort + ' ') + (b.series_name == null ? '' : (b.book_series_index + '').padStart(6, '0') + ' ') + b.book_sort;
+        const keys = authorWithMultipleBooks.books.map(sortKey);
+        expect(keys).toEqual([...keys].sort((a, b) => a.localeCompare(b)));
+      }
+    });
+
+    it('should propagate errors from getBooks', async () => {
+      jest.spyOn(service, 'getBooks').mockRejectedValue(new Error('db down'));
+
+      await expect(service.getAllAuthors()).rejects.toThrow('db down');
     });
   });
 
   describe('getAllTags', () => {
-    it('should call getAllTags and handle response', async () => {
-      // getAllTags has complex transformation logic that requires proper BooksService mock
-      // The mock doesn't replicate the full transformation, so we expect it might fail
-      try {
-        const result = await service.getAllTags();
-        // If it succeeds, verify it's defined
-        expect(result).toBeDefined();
-      } catch (error) {
-        // If it fails, verify it's because of the mock limitation
-        expect(error.message).toMatch(/forEach/);
+    it('should group books by tag', async () => {
+      const result = await service.getAllTags();
+
+      expect(Array.isArray(result)).toBe(true);
+      for (const tag of result) {
+        expect(tag.books.length).toBeGreaterThan(0);
       }
+    });
+
+    it('should propagate errors from getBooks', async () => {
+      jest.spyOn(service, 'getBooks').mockRejectedValue(new Error('db down'));
+
+      await expect(service.getAllTags()).rejects.toThrow('db down');
     });
   });
 
@@ -247,6 +337,94 @@ describe('CalibreDb1Service', () => {
 
       expect(result[0]).toHaveProperty('book_id');
       expect(result[0]).toHaveProperty('book_title');
+    });
+
+    it('should attach downloads and ratings from user history to the matching book', async () => {
+      const [book] = await service.getBooks(1);
+      const downloadDate = new Date(book.last_modified.getTime() + 1000 * 3600 * 24 * 365);
+      const user = {
+        id: 'u1',
+        local: { username: 'alice', firstname: '', lastname: '' },
+        history: {
+          downloadedBooks: [{ id: book.book_id, date: downloadDate, data: { data_format: 'EPUB' } }],
+          ratings: [{ book_id: book.book_id, rating: 4, date: downloadDate }],
+        },
+      } as unknown as User;
+
+      const [result] = (await service.fillBooksFromUser([book], Promise.resolve([user]), false)) as any[];
+
+      expect(result.history.downloads).toHaveLength(1);
+      expect(result.history.downloads[0].user_name).toBe('alice');
+      expect(result.history.ratings).toHaveLength(1);
+      expect(result.readerRating).toBe(4);
+      expect(result.readerRatingCount).toBe(1);
+      expect(result.last_modified).toEqual(downloadDate);
+    });
+
+    it('should prefer first/last name over username when both are available', async () => {
+      const [book] = await service.getBooks(1);
+      const user = {
+        id: 'u1',
+        local: { username: 'alice', firstname: 'Alice', lastname: 'Doe' },
+        history: { downloadedBooks: [{ id: book.book_id, date: new Date(0), data: { data_format: 'EPUB' } }], ratings: [] },
+      } as unknown as User;
+
+      const [result] = (await service.fillBooksFromUser([book], Promise.resolve([user]), false)) as any[];
+
+      expect(result.history.downloads[0].user_name).toBe('Alice Doe');
+    });
+
+    it('should strip internal fields when cleanBook is true', async () => {
+      const [book] = await service.getBooks(1);
+
+      const [result] = (await service.fillBooksFromUser([book], Promise.resolve([]), true)) as any[];
+
+      expect(result['book_path']).toBeUndefined();
+      expect(result['tag_id']).toBeUndefined();
+      expect(result['data']).toBeUndefined();
+    });
+
+    it('should reach into nested books arrays (e.g. series/tags) to apply user history', async () => {
+      const books = await service.getBooks(2);
+      const group = { books } as any;
+      const user = {
+        id: 'u1',
+        local: { username: 'alice' },
+        history: { downloadedBooks: [{ id: books[0].book_id, date: new Date(), data: { data_format: 'EPUB' } }], ratings: [] },
+      } as unknown as User;
+
+      // the top-level shape (grouped objects) is preserved; only the nested books get mutated
+      const result = (await service.fillBooksFromUser([group], Promise.resolve([user]), false)) as any[];
+
+      expect(result).toHaveLength(1);
+      expect(result[0].books).toHaveLength(books.length);
+      expect(result[0].books[0].history.downloads).toHaveLength(1);
+    });
+
+    it('should reject when the users promise rejects', async () => {
+      await expect(service.fillBooksFromUser([], Promise.reject('user lookup failed'), false)).rejects.toEqual('user lookup failed');
+    });
+  });
+
+  describe('SQL fragment helpers', () => {
+    it('_concat should build a GROUP_CONCAT subquery joining through the expected link table', () => {
+      const result = service['_concat']('author', 'book', 'name');
+
+      expect(result).toContain('books_authors_link');
+      expect(result).toContain('GROUP_CONCAT');
+    });
+
+    it('_concat_simple should build a distinct GROUP_CONCAT subquery by default', () => {
+      const result = service['_concat_simple']('data', 'books', 'book', 'format');
+
+      expect(result).toContain('SELECT DISTINCT');
+      expect(result).toContain('data.format');
+    });
+
+    it('_concat_simple should allow disabling DISTINCT', () => {
+      const result = service['_concat_simple']('data', 'books', 'book', 'name', false);
+
+      expect(result).not.toContain('DISTINCT');
     });
   });
 });

--- a/apps/api/src/app/series/series.service.spec.ts
+++ b/apps/api/src/app/series/series.service.spec.ts
@@ -3,6 +3,7 @@ import { SeriesService } from './series.service';
 import { CalibreDb1Service } from '../database/calibre-db1.service';
 import { Series } from '@my-calibre-server/api-interfaces';
 import { CacheService } from '../cache/cache.service';
+import { BooksService } from '../books/books.service';
 import * as sharp from 'sharp';
 import { existsSync, mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
@@ -49,6 +50,7 @@ describe('SeriesService', () => {
   });
 
   afterEach(() => {
+    jest.restoreAllMocks();
     jest.clearAllMocks();
   });
 
@@ -156,23 +158,106 @@ describe('SeriesService', () => {
 
       await expect(service.calculateSpritesSeriesThumbnail()).rejects.toThrow('DB Error');
     });
+
+    it('should build one sprite sheet per group of series that needs regeneration', async () => {
+      const series = [{ series_id: 1 }, { series_id: 2 }, { series_id: 60 }] as unknown as Series[];
+      mockCalibreDbService.getAllSeries.mockResolvedValue(series);
+      jest.spyOn(service, 'getSpriteDate').mockReturnValue(0);
+      jest.spyOn(service, 'getThumbnailDate').mockReturnValue(1);
+      const createSpritesSeriesSpy = jest.spyOn(service, 'createSpritesSeries').mockResolvedValue(undefined);
+
+      await service.calculateSpritesSeriesThumbnail();
+
+      expect(createSpritesSeriesSpy).toHaveBeenCalledTimes(2);
+      expect(createSpritesSeriesSpy.mock.calls.map((c) => c[0]).sort((a, b) => a - b)).toEqual([0, 50]);
+    });
+
+    it('should skip a sprite group that is already up to date', async () => {
+      const series = [{ series_id: 1 }] as unknown as Series[];
+      mockCalibreDbService.getAllSeries.mockResolvedValue(series);
+      jest.spyOn(service, 'getSpriteDate').mockReturnValue(2);
+      jest.spyOn(service, 'getThumbnailDate').mockReturnValue(1);
+      const createSpritesSeriesSpy = jest.spyOn(service, 'createSpritesSeries').mockResolvedValue(undefined);
+
+      await service.calculateSpritesSeriesThumbnail();
+
+      expect(createSpritesSeriesSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('createSpritesSeries', () => {
-    it('should create sprites for a specific index', async () => {
-      mockCalibreDbService.getAllSeries.mockResolvedValue([mockSeries]);
+    let tmpDir: string;
 
-      // This will fail because it tries to access file system, but we test the structure
-      await expect(service.createSpritesSeries(0)).rejects.toThrow();
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'series-service-test-'));
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('should assemble the sprite sheet and write it to disk', async () => {
+      const spritePath = join(tmpDir, 'sprites', 'sprites_series_000000.png');
+      jest.spyOn(service, 'getSpritesPath').mockReturnValue(spritePath);
+      jest.spyOn(service, 'getSpritesSeriesOverlay').mockResolvedValue([]);
+
+      await service.createSpritesSeries(0);
+
+      expect(existsSync(spritePath)).toBe(true);
+    });
+
+    it('should reject when building the overlay fails', async () => {
+      jest.spyOn(service, 'getSpritesPath').mockReturnValue(join(tmpDir, 'sprites_series_000000.png'));
+      jest.spyOn(service, 'getSpritesSeriesOverlay').mockRejectedValue(new Error('overlay failed'));
+
+      await expect(service.createSpritesSeries(0)).rejects.toThrow('overlay failed');
     });
   });
 
   describe('getSpritesSeriesOverlay', () => {
-    it('should get overlay options for series sprites', async () => {
-      mockCalibreDbService.getAllSeries.mockResolvedValue([mockSeries]);
+    it('should build one overlay entry per series in the group, using the error cover when no thumbnail exists', async () => {
+      const series = [{ series_id: 0 }, { series_id: 1 }] as unknown as Series[];
+      mockCalibreDbService.getAllSeries.mockResolvedValue(series);
+      jest.spyOn(BooksService, 'getThumbnailInfo').mockResolvedValue({ width: 100 } as any);
+      jest.spyOn(service, 'getThumbnailPath').mockReturnValue('/does/not/exist.png');
 
-      // This will fail because it tries to access file system, but we test the structure
-      await expect(service.getSpritesSeriesOverlay(0)).rejects.toThrow();
+      const overlay = await service.getSpritesSeriesOverlay(0);
+
+      expect(overlay).toHaveLength(2);
+      // each slot is one THUMBNAIL_HEIGHT (160px) apart
+      expect(overlay[1].left - overlay[0].left).toBe(160);
+    });
+
+    it('should use the real thumbnail path when one exists on disk', async () => {
+      const series = [{ series_id: 0 }] as unknown as Series[];
+      mockCalibreDbService.getAllSeries.mockResolvedValue(series);
+      jest.spyOn(BooksService, 'getThumbnailInfo').mockResolvedValue({ width: 120 } as any);
+      jest.spyOn(service, 'getThumbnailPath').mockReturnValue(__filename); // any real file on disk
+
+      const overlay = await service.getSpritesSeriesOverlay(0);
+
+      expect(overlay[0].input).toBe(__filename);
+    });
+
+    it('should fall back to the error cover info when reading the real thumbnail info fails', async () => {
+      const series = [{ series_id: 0 }] as unknown as Series[];
+      mockCalibreDbService.getAllSeries.mockResolvedValue(series);
+      jest.spyOn(service, 'getThumbnailPath').mockReturnValue(__filename);
+      jest
+        .spyOn(BooksService, 'getThumbnailInfo')
+        .mockResolvedValueOnce({ width: 90 } as any) // err_info
+        .mockRejectedValueOnce('broken thumbnail');
+
+      const overlay = await service.getSpritesSeriesOverlay(0);
+
+      expect(overlay).toHaveLength(1);
+    });
+
+    it('should propagate errors from the database', async () => {
+      jest.spyOn(BooksService, 'getThumbnailInfo').mockResolvedValue({ width: 100 } as any);
+      mockCalibreDbService.getAllSeries.mockRejectedValue('db down');
+
+      await expect(service.getSpritesSeriesOverlay(0)).rejects.toEqual('db down');
     });
   });
 

--- a/apps/api/src/app/users/users.service.spec.ts
+++ b/apps/api/src/app/users/users.service.spec.ts
@@ -155,6 +155,12 @@ describe('UsersService', () => {
 
       expect(result).toBeNull();
     });
+
+    it('should log and rethrow when the database call fails', async () => {
+      mockMyCalibreDbService.findUserByUsername.mockRejectedValue(new Error('db down'));
+
+      await expect(service.findByUsername('testuser')).rejects.toThrow('db down');
+    });
   });
 
   describe('findById', () => {
@@ -175,6 +181,12 @@ describe('UsersService', () => {
 
       expect(result).toBeNull();
     });
+
+    it('should log and rethrow when the database call fails', async () => {
+      mockMyCalibreDbService.findUserById.mockRejectedValue(new Error('db down'));
+
+      await expect(service.findById('user123')).rejects.toThrow('db down');
+    });
   });
 
   describe('findByGoogleId', () => {
@@ -187,6 +199,20 @@ describe('UsersService', () => {
       expect(result.google.id).toBe('google123');
       expect(mockMyCalibreDbService.findUserByGoogleId).toHaveBeenCalledWith('google123');
     });
+
+    it('should return null if user not found', async () => {
+      mockMyCalibreDbService.findUserByGoogleId.mockResolvedValue(null);
+
+      const result = await service.findByGoogleId('nonexistent');
+
+      expect(result).toBeNull();
+    });
+
+    it('should log and rethrow when the database call fails', async () => {
+      mockMyCalibreDbService.findUserByGoogleId.mockRejectedValue(new Error('db down'));
+
+      await expect(service.findByGoogleId('google123')).rejects.toThrow('db down');
+    });
   });
 
   describe('findByFacebookId', () => {
@@ -198,6 +224,46 @@ describe('UsersService', () => {
       expect(result).toBeDefined();
       expect(result.facebook.id).toBe('fb123');
       expect(mockMyCalibreDbService.findUserByFacebookId).toHaveBeenCalledWith('fb123');
+    });
+
+    it('should return null if user not found', async () => {
+      mockMyCalibreDbService.findUserByFacebookId.mockResolvedValue(null);
+
+      const result = await service.findByFacebookId('nonexistent');
+
+      expect(result).toBeNull();
+    });
+
+    it('should log and rethrow when the database call fails', async () => {
+      mockMyCalibreDbService.findUserByFacebookId.mockRejectedValue(new Error('db down'));
+
+      await expect(service.findByFacebookId('fb123')).rejects.toThrow('db down');
+    });
+  });
+
+  describe('findByTemporaryToken', () => {
+    it('should find user by temporary token', async () => {
+      mockMyCalibreDbService.findByTemporaryToken.mockResolvedValue(mockUser);
+
+      const result = await service.findByTemporaryToken('temp-token');
+
+      expect(result).toBeDefined();
+      expect(result.id).toBe('user123');
+      expect(mockMyCalibreDbService.findByTemporaryToken).toHaveBeenCalledWith('temp-token');
+    });
+
+    it('should return null if user not found', async () => {
+      mockMyCalibreDbService.findByTemporaryToken.mockResolvedValue(null);
+
+      const result = await service.findByTemporaryToken('unknown-token');
+
+      expect(result).toBeNull();
+    });
+
+    it('should log and rethrow when the database call fails', async () => {
+      mockMyCalibreDbService.findByTemporaryToken.mockRejectedValue(new Error('db down'));
+
+      await expect(service.findByTemporaryToken('temp-token')).rejects.toThrow('db down');
     });
   });
 
@@ -218,6 +284,20 @@ describe('UsersService', () => {
 
       expect(mockMyCalibreDbService.saveUser).toHaveBeenCalledWith(mockUser, true, false);
     });
+
+    it('should return null when the database reports no document was saved', async () => {
+      mockMyCalibreDbService.saveUser.mockResolvedValue(null);
+
+      const result = await service.saveUser(mockUser);
+
+      expect(result).toBeNull();
+    });
+
+    it('should log and rethrow when the database call fails', async () => {
+      mockMyCalibreDbService.saveUser.mockRejectedValue(new Error('db down'));
+
+      await expect(service.saveUser(mockUser)).rejects.toThrow('db down');
+    });
   });
 
   describe('deleteUser', () => {
@@ -227,6 +307,39 @@ describe('UsersService', () => {
       await service.deleteUser('user123');
 
       expect(mockMyCalibreDbService.deleteUser).toHaveBeenCalledWith('user123');
+    });
+
+    it('should resolve even when the database reports nothing was deleted', async () => {
+      mockMyCalibreDbService.deleteUser.mockResolvedValue(null);
+
+      await expect(service.deleteUser('unknown')).resolves.toBeUndefined();
+    });
+
+    it('should log and rethrow when the database call fails', async () => {
+      mockMyCalibreDbService.deleteUser.mockRejectedValue(new Error('db down'));
+
+      await expect(service.deleteUser('user123')).rejects.toThrow('db down');
+    });
+  });
+
+  describe('mergeUsers', () => {
+    it('should look up both users and merge them', async () => {
+      const userSrc = { ...mockUser, id: 'src' };
+      const userTrg = { ...mockUser, id: 'trg' };
+      mockMyCalibreDbService.findUserById.mockImplementation((id: string) => Promise.resolve(id === 'src' ? userSrc : userTrg));
+      mockMyCalibreDbService.deleteUser.mockResolvedValue(true);
+      mockMyCalibreDbService.saveUser.mockResolvedValue(userTrg);
+
+      await service.mergeUsers('src', 'trg');
+
+      expect(mockMyCalibreDbService.deleteUser).toHaveBeenCalledWith('src');
+      expect(mockMyCalibreDbService.saveUser).toHaveBeenCalledWith(userTrg, true, true);
+    });
+
+    it('should reject when either user cannot be found', async () => {
+      mockMyCalibreDbService.findUserById.mockImplementation((id: string) => Promise.resolve(id === 'src' ? mockUser : null));
+
+      await expect(service.mergeUsers('src', 'trg')).rejects.toThrow('User not found');
     });
   });
 
@@ -308,6 +421,15 @@ describe('UsersService', () => {
 
       expect(apiUser.history.downloadedBooks).toEqual([]);
       expect(apiUser.history.ratings).toEqual([]);
+    });
+
+    it('should empty the downloaded books history for the legacy "toto2" demo account', () => {
+      const demoUser = { ...mockUser, local: { ...mockUser.local, username: 'toto2' }, history: { ...mockUser.history, downloadedBooks: [{ id: 1 }] as any } };
+
+      const apiUser = service.user2API(demoUser);
+
+      // the field is deleted then immediately re-initialized to an empty array by the fallback below it
+      expect(apiUser.history.downloadedBooks).toEqual([]);
     });
   });
 
@@ -412,6 +534,15 @@ describe('UsersService', () => {
       expect(typeof user.local.isAdmin).toBe('boolean');
       expect(user.local.isAdmin).toBe(true);
     });
+
+    it('should generate an id when none is provided', () => {
+      const rawData = { local: { username: 'no-id-user' } };
+
+      const user = service.createUser(rawData);
+
+      expect(user.id).toBeDefined();
+      expect(user.id.length).toBeGreaterThan(0);
+    });
   });
 
   describe('updateLastConnection', () => {
@@ -427,6 +558,12 @@ describe('UsersService', () => {
       expect(mockMyCalibreDbService.findUserById).toHaveBeenCalledWith('user123');
       expect(freshUser.history.lastConnection.getTime()).toBeGreaterThan(new Date('2023-01-01').getTime());
       expect(mockMyCalibreDbService.saveUser).toHaveBeenCalledWith(freshUser, true, false);
+    });
+
+    it('should log (and not throw) when the underlying lookup fails', async () => {
+      mockMyCalibreDbService.findUserById.mockRejectedValue(new Error('db down'));
+
+      await expect(service.updateLastConnection(mockUser)).resolves.toBeUndefined();
     });
   });
 
@@ -470,6 +607,44 @@ describe('UsersService', () => {
 
       // Book should not be added again, but save should still be called
       expect(mockMyCalibreDbService.saveUser).toHaveBeenCalled();
+    });
+
+    it('should initialize the downloaded books array when missing', async () => {
+      const bookData: BookData = { data_id: 1, data_format: 'EPUB', data_size: 1000, data_name: 'test-book' };
+      const user = { ...mockUser, history: { ...mockUser.history, downloadedBooks: undefined as any } };
+      mockMyCalibreDbService.findUserById.mockResolvedValue(user);
+      mockMyCalibreDbService.saveUser.mockResolvedValue(user);
+
+      await service.addDownloadedBook(user, 123, bookData);
+
+      expect(user.history.downloadedBooks.length).toBe(1);
+    });
+
+    it('should sort downloaded books chronologically, converting string dates', async () => {
+      const bookData: BookData = { data_id: 1, data_format: 'EPUB', data_size: 1000, data_name: 'test-book' };
+      const user = {
+        ...mockUser,
+        history: {
+          ...mockUser.history,
+          downloadedBooks: [
+            { id: 1, data: bookData, date: '2023-06-01' as unknown as Date },
+            { id: 2, data: bookData, date: new Date('2023-01-01') },
+          ],
+        },
+      };
+      mockMyCalibreDbService.findUserById.mockResolvedValue(user);
+      mockMyCalibreDbService.saveUser.mockResolvedValue(user);
+
+      await service.addDownloadedBook(user, 3, bookData);
+
+      expect(user.history.downloadedBooks.map((d) => d.id)).toEqual([2, 1, 3]);
+      expect(user.history.downloadedBooks[0].date).toBeInstanceOf(Date);
+    });
+
+    it('should log and rethrow when the underlying lookup fails', async () => {
+      mockMyCalibreDbService.findUserById.mockRejectedValue(new Error('db down'));
+
+      await expect(service.addDownloadedBook(mockUser, 1, {} as BookData)).rejects.toThrow('db down');
     });
   });
 
@@ -523,6 +698,42 @@ describe('UsersService', () => {
       await service.addRatingBook(user, 123, 'Test Book', 5);
 
       expect(user.history.ratings[0].date).toBe(existingDate);
+    });
+
+    it('should initialize the ratings array when missing', async () => {
+      const user = { ...mockUser, history: { ...mockUser.history, ratings: undefined as any } };
+      mockMyCalibreDbService.findUserById.mockResolvedValue(user);
+      mockMyCalibreDbService.saveUser.mockResolvedValue(user);
+
+      await service.addRatingBook(user, 123, 'Test Book', 5);
+
+      expect(user.history.ratings.length).toBe(1);
+    });
+
+    it('should sort ratings chronologically, converting string dates', async () => {
+      const user = {
+        ...mockUser,
+        history: {
+          ...mockUser.history,
+          ratings: [
+            { book_id: 1, rating: 3, date: '2023-06-01' as unknown as Date, book_name: 'Older API rating' },
+            { book_id: 2, rating: 4, date: new Date('2023-01-01'), book_name: 'Newest' },
+          ],
+        },
+      };
+      mockMyCalibreDbService.findUserById.mockResolvedValue(user);
+      mockMyCalibreDbService.saveUser.mockResolvedValue(user);
+
+      await service.addRatingBook(user, 3, 'New Book', 5);
+
+      expect(user.history.ratings.map((r) => r.book_id)).toEqual([2, 1, 3]);
+      expect(user.history.ratings[1].date).toBeInstanceOf(Date);
+    });
+
+    it('should log and rethrow when the underlying lookup fails', async () => {
+      mockMyCalibreDbService.findUserById.mockRejectedValue(new Error('db down'));
+
+      await expect(service.addRatingBook(mockUser, 1, 'Book', 5)).rejects.toThrow('db down');
     });
   });
 
@@ -664,6 +875,140 @@ describe('UsersService', () => {
       await service.mergeAndSaveUsers(userSrc, userTrg);
 
       expect(userTrg.history.downloadedBooks.length).toBe(2);
+    });
+
+    it('should not duplicate a downloaded book already present on the target', async () => {
+      const bookData: BookData = { data_id: 1, data_format: 'EPUB', data_size: 1000, data_name: 'book' };
+      const userSrc = { ...mockUser, id: 'src', history: { ...mockUser.history, downloadedBooks: [{ id: 1, data: bookData, date: new Date() }] } };
+      const userTrg = { ...mockUser, id: 'trg', history: { ...mockUser.history, downloadedBooks: [{ id: 1, data: bookData, date: new Date() }] } };
+      mockMyCalibreDbService.deleteUser.mockResolvedValue(true);
+      mockMyCalibreDbService.saveUser.mockResolvedValue(userTrg);
+
+      await service.mergeAndSaveUsers(userSrc, userTrg);
+
+      expect(userTrg.history.downloadedBooks.length).toBe(1);
+    });
+
+    it('should default src/trg history arrays to empty when missing', async () => {
+      const userSrc = { ...mockUser, id: 'src', history: { lastConnection: undefined, downloadedBooks: undefined, ratings: undefined } as any };
+      const userTrg = { ...mockUser, id: 'trg', history: { lastConnection: undefined, downloadedBooks: undefined, ratings: undefined } as any };
+      mockMyCalibreDbService.deleteUser.mockResolvedValue(true);
+      mockMyCalibreDbService.saveUser.mockResolvedValue(userTrg);
+
+      await service.mergeAndSaveUsers(userSrc, userTrg);
+
+      expect(userTrg.history.downloadedBooks).toEqual([]);
+      expect(userTrg.history.ratings).toEqual([]);
+    });
+
+    it('should add a new rating from the source when the target has none for that book', async () => {
+      const userSrc = { ...mockUser, id: 'src', history: { ...mockUser.history, ratings: [{ book_id: 1, rating: 4, date: new Date('2023-01-01'), book_name: 'Book' }] } };
+      const userTrg = { ...mockUser, id: 'trg', history: { ...mockUser.history, ratings: [] } };
+      mockMyCalibreDbService.deleteUser.mockResolvedValue(true);
+      mockMyCalibreDbService.saveUser.mockResolvedValue(userTrg);
+
+      await service.mergeAndSaveUsers(userSrc, userTrg);
+
+      expect(userTrg.history.ratings).toEqual([{ book_id: 1, rating: 4, date: new Date('2023-01-01'), book_name: 'Book' }]);
+    });
+
+    it('should keep the more recent rating when both users rated the same book', async () => {
+      const userSrc = { ...mockUser, id: 'src', history: { ...mockUser.history, ratings: [{ book_id: 1, rating: 5, date: new Date('2023-06-01'), book_name: 'Book' }] } };
+      const userTrg = { ...mockUser, id: 'trg', history: { ...mockUser.history, ratings: [{ book_id: 1, rating: 2, date: new Date('2023-01-01'), book_name: 'Book' }] } };
+      mockMyCalibreDbService.deleteUser.mockResolvedValue(true);
+      mockMyCalibreDbService.saveUser.mockResolvedValue(userTrg);
+
+      await service.mergeAndSaveUsers(userSrc, userTrg);
+
+      expect(userTrg.history.ratings.length).toBe(1);
+      expect(userTrg.history.ratings[0].rating).toBe(5);
+    });
+
+    it('should keep the target rating when it is more recent than the source', async () => {
+      const userSrc = { ...mockUser, id: 'src', history: { ...mockUser.history, ratings: [{ book_id: 1, rating: 5, date: new Date('2023-01-01'), book_name: 'Book' }] } };
+      const userTrg = { ...mockUser, id: 'trg', history: { ...mockUser.history, ratings: [{ book_id: 1, rating: 2, date: new Date('2023-06-01'), book_name: 'Book' }] } };
+      mockMyCalibreDbService.deleteUser.mockResolvedValue(true);
+      mockMyCalibreDbService.saveUser.mockResolvedValue(userTrg);
+
+      await service.mergeAndSaveUsers(userSrc, userTrg);
+
+      expect(userTrg.history.ratings[0].rating).toBe(2);
+    });
+
+    it('should keep the most recent lastConnection between both users', async () => {
+      const userSrc = { ...mockUser, id: 'src', history: { ...mockUser.history, lastConnection: new Date('2023-06-01') } };
+      const userTrg = { ...mockUser, id: 'trg', history: { ...mockUser.history, lastConnection: new Date('2023-01-01') } };
+      mockMyCalibreDbService.deleteUser.mockResolvedValue(true);
+      mockMyCalibreDbService.saveUser.mockResolvedValue(userTrg);
+
+      await service.mergeAndSaveUsers(userSrc, userTrg);
+
+      expect(userTrg.history.lastConnection).toEqual(new Date('2023-06-01'));
+    });
+
+    it('should not overwrite an existing target field with an empty source field', async () => {
+      const userSrc = { ...mockUser, id: 'src', local: { ...mockUser.local, firstname: undefined } };
+      const userTrg = { ...mockUser, id: 'trg', local: { ...mockUser.local, firstname: 'Kept' } };
+      mockMyCalibreDbService.deleteUser.mockResolvedValue(true);
+      mockMyCalibreDbService.saveUser.mockResolvedValue(userTrg);
+
+      await service.mergeAndSaveUsers(userSrc, userTrg);
+
+      expect(userTrg.local.firstname).toBe('Kept');
+    });
+
+    it('should transfer the salt from the source when the target has no hashed password', async () => {
+      const userSrc = { ...mockUser, id: 'src', local: { ...mockUser.local, salt: 'src-salt', hashedPassword: undefined } };
+      const userTrg = { ...mockUser, id: 'trg', local: { ...mockUser.local, salt: 'trg-salt', hashedPassword: undefined } };
+      mockMyCalibreDbService.deleteUser.mockResolvedValue(true);
+      mockMyCalibreDbService.saveUser.mockResolvedValue(userTrg);
+
+      await service.mergeAndSaveUsers(userSrc, userTrg);
+
+      expect(userTrg.local.salt).toBe('src-salt');
+    });
+  });
+
+  describe('createTemporaryToken', () => {
+    it('should create a short-lived JWT containing only the user id', () => {
+      const token = service.createTemporaryToken(mockUser);
+
+      expect(typeof token).toBe('string');
+      const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
+      expect(payload.id).toBe('user123');
+      expect(payload.local).toBeUndefined();
+    });
+  });
+
+  describe('getBearerUser', () => {
+    const buildRequest = (authorization?: string): any => ({ headers: authorization !== undefined ? { authorization } : {} });
+
+    it('should return the user for a valid Bearer token', async () => {
+      const token = service.createToken(mockUser);
+      mockMyCalibreDbService.findUserById.mockResolvedValue(mockUser);
+
+      const result = await service.getBearerUser(buildRequest(`Bearer ${token}`));
+
+      expect(result.id).toBe('user123');
+    });
+
+    it('should throw when there is no authorization header', async () => {
+      // Note: `request.headers` being a (truthy) empty object means the code still tries to
+      // read/split the missing `authorization` value instead of hitting the intended "No token"
+      // guard - this documents that pre-existing behavior rather than the intended message.
+      await expect(service.getBearerUser(buildRequest())).rejects.toThrow(TypeError);
+    });
+
+    it('should throw when the authorization header has the wrong shape', async () => {
+      await expect(service.getBearerUser(buildRequest('MalformedHeaderWithoutScheme'))).rejects.toThrow('No token');
+    });
+
+    it('should throw when the scheme is not Bearer', async () => {
+      await expect(service.getBearerUser(buildRequest('Basic sometoken'))).rejects.toThrow('No token');
+    });
+
+    it('should propagate the error when the token is invalid', async () => {
+      await expect(service.getBearerUser(buildRequest('Bearer invalid.token.here'))).rejects.toBeDefined();
     });
   });
 });

--- a/apps/api/src/app/utils/mail.service.spec.ts
+++ b/apps/api/src/app/utils/mail.service.spec.ts
@@ -1,0 +1,108 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import * as nodemailer from 'nodemailer';
+import { MailService } from './mail.service';
+
+jest.mock('nodemailer', () => ({
+  createTransport: jest.fn(),
+}));
+
+describe('MailService', () => {
+  let service: MailService;
+  let sendMailMock: jest.Mock;
+
+  const configValues: Record<string, string> = {
+    SMTP_ENCRYPTION: 'SSL',
+    SMTP_USER_NAME: 'user@example.com',
+    SMTP_PASSWORD: 'secret',
+    SMTP_SERVER_NAME: 'smtp.example.com',
+  };
+
+  const mockConfigService = {
+    get: jest.fn((key: string) => configValues[key]),
+  };
+
+  beforeEach(async () => {
+    sendMailMock = jest.fn();
+    (nodemailer.createTransport as jest.Mock).mockReturnValue({ sendMail: sendMailMock });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MailService, { provide: ConfigService, useValue: mockConfigService }],
+    }).compile();
+
+    service = module.get<MailService>(MailService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should build an smtps:// transport URL with the username percent-encoded when SSL is configured', async () => {
+    sendMailMock.mockImplementation((options, cb) => cb(null));
+
+    await service.sendMail('dest@example.com', 'Subject', '<p>body</p>');
+
+    expect(nodemailer.createTransport).toHaveBeenCalledWith('smtps://user%40example.com:secret@smtp.example.com');
+  });
+
+  it('should build a plain smtp:// transport URL when SSL is not configured', async () => {
+    configValues['SMTP_ENCRYPTION'] = 'NONE';
+    sendMailMock.mockImplementation((options, cb) => cb(null));
+
+    await service.sendMail('dest@example.com', 'Subject', '<p>body</p>');
+
+    expect(nodemailer.createTransport).toHaveBeenCalledWith('smtp://user%40example.com:secret@smtp.example.com');
+
+    configValues['SMTP_ENCRYPTION'] = 'SSL';
+  });
+
+  it('should send mail with from/to/subject/html and no attachment by default', async () => {
+    sendMailMock.mockImplementation((options, cb) => cb(null));
+
+    await service.sendMail('dest@example.com', 'Hello', '<p>Hi</p>');
+
+    expect(sendMailMock).toHaveBeenCalledWith(
+      {
+        from: '<user@example.com>',
+        to: 'dest@example.com',
+        subject: 'Hello',
+        html: '<p>Hi</p>',
+      },
+      expect.any(Function)
+    );
+  });
+
+  it('should include an attachment when filename and path are both provided', async () => {
+    sendMailMock.mockImplementation((options, cb) => cb(null));
+
+    await service.sendMail('dest@example.com', 'Hello', '<p>Hi</p>', 'book.epub', '/tmp/book.epub');
+
+    expect(sendMailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: [{ filename: 'book.epub', path: '/tmp/book.epub' }],
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('should not add an attachment when only the filename is provided', async () => {
+    sendMailMock.mockImplementation((options, cb) => cb(null));
+
+    await service.sendMail('dest@example.com', 'Hello', '<p>Hi</p>', 'book.epub');
+
+    expect(sendMailMock).toHaveBeenCalledWith(expect.not.objectContaining({ attachments: expect.anything() }), expect.any(Function));
+  });
+
+  it('should reject and log when sending the mail fails', async () => {
+    const error = new Error('SMTP down');
+    sendMailMock.mockImplementation((options, cb) => cb(error));
+    const loggerErrorSpy = jest.spyOn(service.logger, 'error').mockImplementation(() => undefined);
+
+    await expect(service.sendMail('dest@example.com', 'Hello', '<p>Hi</p>')).rejects.toBe(error);
+    expect(loggerErrorSpy).toHaveBeenCalledWith(error);
+  });
+});

--- a/apps/frontend/src/app/components/authent/user.service.spec.ts
+++ b/apps/frontend/src/app/components/authent/user.service.spec.ts
@@ -3,6 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { JwtHelperService } from '@auth0/angular-jwt';
 import { ApiReturn, User, UserAPI } from '@my-calibre-server/api-interfaces';
 import { of, throwError } from 'rxjs';
+import { WindowService } from '../../core/util/window.service';
 import { UserService } from './user.service';
 
 describe('UserService', () => {
@@ -412,6 +413,259 @@ describe('UserService', () => {
           }, 100);
         }
       });
+    });
+  });
+
+  describe('Error message extraction (via error callbacks)', () => {
+    it('should use the last entry when the error payload is an array', async () => {
+      mockHttpClient.post.mockReturnValue(throwError(() => ({ error: [{ statusText: 'first' }, { statusText: 'last' }] })));
+
+      await expect(service.save(mockUser)).rejects.toBe('last');
+    });
+
+    it('should use the nested error when it carries a message', async () => {
+      mockHttpClient.post.mockReturnValue(throwError(() => ({ error: { message: 'nested message' } })));
+
+      await expect(service.remove(mockUser)).rejects.toBe('nested message');
+    });
+
+    it('should fall back to the nested error object when it has no message', async () => {
+      const nestedError = { code: 'ERR_TEST' };
+      mockHttpClient.post.mockReturnValue(throwError(() => ({ error: nestedError })));
+
+      await expect(service.resetPassword(mockUser)).rejects.toBe(nestedError);
+    });
+
+    it('should use statusText when present on a plain error', async () => {
+      mockHttpClient.post.mockReturnValue(throwError(() => ({ statusText: 'Unauthorized' })));
+
+      await expect(service.save(mockUser)).rejects.toBe('Unauthorized');
+    });
+
+    it('should fall back to "Connection error" when the error carries no usable information', async () => {
+      mockHttpClient.post.mockReturnValue(throwError(() => ''));
+
+      await expect(service.save(mockUser)).rejects.toBe('Connection error');
+    });
+
+    it('should recover gracefully when reading the error payload throws', async () => {
+      const throwingError = {
+        get error() {
+          throw new Error('boom while reading error');
+        },
+        message: 'fallback message',
+      };
+      mockHttpClient.post.mockReturnValue(throwError(() => throwingError));
+
+      await expect(service.save(mockUser)).rejects.toBe('fallback message');
+    });
+  });
+
+  describe('Additional error branches', () => {
+    it('should reject when refreshUser request errors', async () => {
+      mockHttpClient.get.mockReturnValue(throwError(() => 'network down'));
+
+      await expect(service.refreshUser()).rejects.toBe('network down');
+    });
+
+    it('should reject when getAll request errors', async () => {
+      mockHttpClient.get.mockReturnValue(throwError(() => 'network down'));
+
+      await expect(service.getAll()).rejects.toBe('network down');
+    });
+
+    it('should reject when getAll response has no users', async () => {
+      mockHttpClient.get.mockReturnValue(of({} as ApiReturn));
+
+      await expect(service.getAll()).rejects.toBe('Cannot get users');
+    });
+
+    it('should reject when merge request errors', async () => {
+      mockHttpClient.post.mockReturnValue(throwError(() => 'network down'));
+
+      await expect(service.merge(mockUser, mockUser)).rejects.toBe('network down');
+    });
+
+    it('should reject when merge response has no users', async () => {
+      mockHttpClient.post.mockReturnValue(of({} as ApiReturn));
+
+      await expect(service.merge(mockUser, mockUser)).rejects.toBe('Cannot merge user');
+    });
+
+    it('should reject when resetPassword response has no ok field', async () => {
+      mockHttpClient.post.mockReturnValue(of({} as ApiReturn));
+
+      await expect(service.resetPassword(mockUser)).rejects.toBe('something go wrong');
+    });
+
+    it('should reject when unlinkGoogle response has no user', async () => {
+      mockHttpClient.get.mockReturnValue(of({} as ApiReturn));
+
+      await expect(service.unlinkGoogle('user123')).rejects.toBe('Cannot get users');
+    });
+
+    it('should reject when unlinkGoogle request errors', async () => {
+      mockHttpClient.get.mockReturnValue(throwError(() => 'network down'));
+
+      await expect(service.unlinkGoogle('user123')).rejects.toBe('network down');
+    });
+  });
+
+  describe('_doPost response branches (via login)', () => {
+    it('should resolve with the user when the response has no id_token but has a user', async () => {
+      mockHttpClient.post.mockReturnValue(of({ user: mockUserAPI } as ApiReturn));
+
+      const result = await service.login('testuser', 'password');
+
+      expect(result).toEqual(mockUserAPI);
+    });
+
+    it('should reject when the response has neither id_token nor user', async () => {
+      mockHttpClient.post.mockReturnValue(of({} as ApiReturn));
+
+      await expect(service.login('testuser', 'password')).rejects.toBeUndefined();
+    });
+  });
+
+  describe('_doGet response branches (via loginFacebook)', () => {
+    it('should resolve with the user when the response has no id_token but has a user', async () => {
+      mockHttpClient.get.mockReturnValue(of({ user: mockUserAPI } as ApiReturn));
+
+      const result = await service.loginFacebook({ code: 'abc' });
+
+      expect(result).toEqual(mockUserAPI);
+    });
+
+    it('should resolve with an empty string when the response has neither id_token nor user', async () => {
+      mockHttpClient.get.mockReturnValue(of({} as ApiReturn));
+
+      const result = await service.loginFacebook({ code: 'abc' });
+
+      expect(result).toBe('');
+    });
+
+    it('should reject with the extracted error message when the request errors', async () => {
+      mockHttpClient.get.mockReturnValue(throwError(() => ({ message: 'boom' })));
+
+      await expect(service.loginFacebook({ code: 'abc' })).rejects.toBe('boom');
+    });
+  });
+
+  describe('_parseQueryString', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const parse = (str: any) => (service as any)._parseQueryString(str);
+
+    it('should return an empty object for non-string input', () => {
+      expect(parse(undefined)).toEqual({});
+    });
+
+    it('should return an empty object once separators are stripped from an otherwise empty string', () => {
+      expect(parse('?')).toEqual({});
+    });
+
+    it('should parse a simple key=value pair', () => {
+      expect(parse('code=abc123')).toEqual({ code: 'abc123' });
+    });
+
+    it('should treat a key without "=" as null', () => {
+      expect(parse('flag')).toEqual({ flag: null });
+    });
+
+    it('should turn a repeated key into an array', () => {
+      expect(parse('a=1&a=2')).toEqual({ a: ['1', '2'] });
+    });
+
+    it('should keep accumulating repeated keys past the second occurrence', () => {
+      expect(parse('a=1&a=2&a=3')).toEqual({ a: ['1', '2', '3'] });
+    });
+
+    it('should decode percent-encoding and turn + into spaces', () => {
+      expect(parse('msg=hello+world%21')).toEqual({ msg: 'hello world!' });
+    });
+  });
+
+  describe('OAuth popup flow (_startLoginOAuth)', () => {
+    let fakeWindow: { location: { href: string }; close: jest.Mock };
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      fakeWindow = { location: { href: '' }, close: jest.fn() };
+      jest.spyOn(WindowService, 'createWindow').mockReturnValue(fakeWindow as unknown as Window);
+    });
+
+    afterEach(() => {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+      jest.restoreAllMocks();
+    });
+
+    it('should reject with a timeout once the polling budget is exhausted', async () => {
+      const promise = service.startLoginFacebook();
+      // loopCount starts at 600 and decrements every 100ms tick until it goes negative
+      jest.advanceTimersByTime(100 * 602);
+
+      await expect(promise).rejects.toEqual('Time out');
+      expect(fakeWindow.close).toHaveBeenCalled();
+    });
+
+    it('should keep polling without crashing when reading the window location throws', () => {
+      Object.defineProperty(fakeWindow, 'location', {
+        get() {
+          throw new Error('cross-origin');
+        },
+      });
+      const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+
+      service.startLoginFacebook();
+      expect(() => jest.advanceTimersByTime(100)).not.toThrow();
+      expect(logSpy).toHaveBeenCalledWith('Error:', expect.any(Error));
+    });
+
+    it('should resolve after a successful Facebook code callback', async () => {
+      mockHttpClient.get.mockReturnValue(of({ id_token: mockJwtToken } as ApiReturn));
+
+      const promise = service.startLoginFacebook();
+      fakeWindow.location.href = 'http://localhost/assets/logged.html?code=abc123';
+      jest.advanceTimersByTime(100);
+
+      await expect(promise).resolves.toBeUndefined();
+      expect(fakeWindow.close).toHaveBeenCalled();
+    });
+
+    it('should resolve after a successful Google code callback', async () => {
+      mockHttpClient.get.mockReturnValue(of({ id_token: mockJwtToken } as ApiReturn));
+
+      const promise = service.startLoginGoogle();
+      fakeWindow.location.href = 'http://localhost/assets/logged.html?code=abc123';
+      jest.advanceTimersByTime(100);
+
+      await expect(promise).resolves.toBeUndefined();
+    });
+
+    it('should reject when the code callback login request fails', async () => {
+      mockHttpClient.get.mockReturnValue(throwError(() => ({ message: 'boom' })));
+
+      const promise = service.startLoginFacebook();
+      fakeWindow.location.href = 'http://localhost/assets/logged.html?code=abc123';
+      jest.advanceTimersByTime(100);
+
+      await expect(promise).rejects.toBe('boom');
+    });
+
+    it('should reject when the callback URL has neither a code nor an error message', async () => {
+      const promise = service.startLoginFacebook();
+      fakeWindow.location.href = 'http://localhost/assets/logged.html?foo=bar';
+      jest.advanceTimersByTime(100);
+
+      await expect(promise).rejects.toEqual('Login error');
+    });
+
+    it('should reject with the decoded error message when the callback URL carries one', async () => {
+      const promise = service.startLoginFacebook();
+      fakeWindow.location.href = 'http://localhost/assets/logged.html?error_message=Access+denied';
+      jest.advanceTimersByTime(100);
+
+      await expect(promise).rejects.toEqual('Access denied');
     });
   });
 });

--- a/apps/frontend/src/app/components/book/book-card/book-card.component.spec.ts
+++ b/apps/frontend/src/app/components/book/book-card/book-card.component.spec.ts
@@ -1,0 +1,33 @@
+import { Router } from '@angular/router';
+import { Book } from '@my-calibre-server/api-interfaces';
+import { BookCardComponent } from './book-card.component';
+
+describe('BookCardComponent', () => {
+  let component: BookCardComponent;
+  let mockRouter: jest.Mocked<Router>;
+
+  beforeEach(() => {
+    mockRouter = { navigate: jest.fn() } as unknown as jest.Mocked<Router>;
+    component = new BookCardComponent(mockRouter);
+  });
+
+  it('should be created with default inputs', () => {
+    expect(component).toBeTruthy();
+    expect(component.book).toBeInstanceOf(Book);
+    expect(component.book.book_id).toBe(0);
+    expect(component.index).toBe(-1);
+    expect(component.thumbnailUrlBase).toBe('/api/book/thumbnail');
+  });
+
+  describe('openBook', () => {
+    it('should stop event propagation and navigate to the book page', () => {
+      const event = { stopPropagation: jest.fn() } as unknown as Event;
+      component.book = { ...new Book(), book_id: 42 };
+
+      component.openBook(event);
+
+      expect(event.stopPropagation).toHaveBeenCalled();
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/book', 42]);
+    });
+  });
+});

--- a/apps/frontend/src/app/components/book/book.service.spec.ts
+++ b/apps/frontend/src/app/components/book/book.service.spec.ts
@@ -1,0 +1,362 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { ApiReturn, Book, BookRating, User } from '@my-calibre-server/api-interfaces';
+import { of, throwError } from 'rxjs';
+import { BookService } from './book.service';
+
+describe('BookService', () => {
+  let service: BookService;
+  let mockHttpClient: jest.Mocked<HttpClient>;
+
+  const buildBook = (overrides: Partial<Book> = {}): Book =>
+    ({
+      book_id: 1,
+      book_title: 'Some Book',
+      book_sort: 'Some Book',
+      book_has_cover: 'y',
+      book_path: '/path',
+      book_series_index: 1,
+      author_id: [1],
+      author_name: ['Author'],
+      author_sort: ['Author'],
+      tag_id: [1],
+      tag_name: ['Tag'],
+      lang_id: 1,
+      lang_code: 'en',
+      series_id: '1',
+      rating: '5',
+      series_name: 'Series',
+      series_sort: 'Series',
+      comment: 'comment',
+      book_date: new Date('2020-01-01'),
+      timestamp: new Date('2020-01-01'),
+      last_modified: new Date('2020-01-01'),
+      data: [],
+      history: { ratings: [], downloads: [] },
+      readerRating: 0,
+      readerRatingCount: 0,
+      ...overrides,
+    }) as Book;
+
+  beforeEach(() => {
+    mockHttpClient = {
+      get: jest.fn(),
+      post: jest.fn(),
+    } as any;
+
+    TestBed.configureTestingModule({
+      providers: [BookService, { provide: HttpClient, useValue: mockHttpClient }],
+    });
+
+    service = TestBed.inject(BookService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getBooks', () => {
+    it('should resolve with books and convert string book_date to Date', async () => {
+      const book = buildBook({ book_date: '2020-05-01' as unknown as Date });
+      mockHttpClient.get.mockReturnValue(of({ books: [book] } as ApiReturn));
+
+      const result = await service.getBooks();
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/api/book');
+      expect(result[0].book_date).toBeInstanceOf(Date);
+    });
+
+    it('should reject when response has no books', async () => {
+      mockHttpClient.get.mockReturnValue(of({} as ApiReturn));
+
+      await expect(service.getBooks()).rejects.toEqual('Cannot read books');
+    });
+
+    it('should reject when the request errors', async () => {
+      mockHttpClient.get.mockReturnValue(throwError(() => 'network error'));
+
+      await expect(service.getBooks()).rejects.toEqual('network error');
+    });
+  });
+
+  describe('getNewBooks', () => {
+    it('should resolve with new books and convert string book_date to Date', async () => {
+      const book = buildBook({ book_date: '2020-05-01' as unknown as Date });
+      mockHttpClient.get.mockReturnValue(of({ books: [book] } as ApiReturn));
+
+      const result = await service.getNewBooks();
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/api/book/new');
+      expect(result[0].book_date).toBeInstanceOf(Date);
+    });
+
+    it('should reject when response has no books', async () => {
+      mockHttpClient.get.mockReturnValue(of({} as ApiReturn));
+
+      await expect(service.getNewBooks()).rejects.toEqual('Cannot read books');
+    });
+
+    it('should reject when the request errors', async () => {
+      mockHttpClient.get.mockReturnValue(throwError(() => 'network error'));
+
+      await expect(service.getNewBooks()).rejects.toEqual('network error');
+    });
+  });
+
+  describe('getBook', () => {
+    it('should resolve with the book and convert string book_date to Date', async () => {
+      const book = buildBook({ book_date: '2020-05-01' as unknown as Date });
+      mockHttpClient.get.mockReturnValue(of({ book } as ApiReturn));
+
+      const result = await service.getBook('1');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/api/book/1');
+      expect(result.book_date).toBeInstanceOf(Date);
+    });
+
+    it('should reject when response has no book', async () => {
+      mockHttpClient.get.mockReturnValue(of({} as ApiReturn));
+
+      await expect(service.getBook('1')).rejects.toEqual('Cannot read book');
+    });
+
+    it('should reject when the request errors', async () => {
+      mockHttpClient.get.mockReturnValue(throwError(() => 'network error'));
+
+      await expect(service.getBook('1')).rejects.toEqual('network error');
+    });
+  });
+
+  describe('cloneBook', () => {
+    it('should deep-copy array fields so mutating the clone does not affect the source', () => {
+      const src = buildBook();
+
+      const clone = service.cloneBook(src);
+      clone.author_id.push(99);
+      clone.tag_id.push(99);
+
+      expect(clone).not.toBe(src);
+      expect(src.author_id).toEqual([1]);
+      expect(src.tag_id).toEqual([1]);
+      expect(clone.author_id).toEqual([1, 99]);
+    });
+
+    it('should default tag_id, tag_name and data to empty arrays when absent on the source', () => {
+      const src = buildBook({ tag_id: undefined, tag_name: undefined, data: undefined });
+
+      const clone = service.cloneBook(src);
+
+      expect(clone.tag_id).toEqual([]);
+      expect(clone.tag_name).toEqual([]);
+      expect(clone.data).toEqual([]);
+    });
+  });
+
+  describe('updateRating', () => {
+    it('should resolve with ok on success', async () => {
+      mockHttpClient.post.mockReturnValue(of({ ok: 'ok' } as ApiReturn));
+
+      const result = await service.updateRating(1, 5);
+
+      expect(mockHttpClient.post).toHaveBeenCalledTimes(1);
+      const [url, body, options] = mockHttpClient.post.mock.calls[0];
+      expect(url).toEqual('/api/book/1/rating/');
+      expect(body).toEqual(JSON.stringify({ rating: 5 }));
+      expect((options?.headers as HttpHeaders).get('Accept')).toEqual('application/json');
+      expect((options?.headers as HttpHeaders).get('Content-Type')).toEqual('application/json');
+      expect(result).toEqual('ok');
+    });
+
+    it('should reject when response has no ok field', async () => {
+      mockHttpClient.post.mockReturnValue(of({} as ApiReturn));
+
+      await expect(service.updateRating(1, 5)).rejects.toEqual('Cannot update rating');
+    });
+
+    it('should reject when the request errors', async () => {
+      mockHttpClient.post.mockReturnValue(throwError(() => 'network error'));
+
+      await expect(service.updateRating(1, 5)).rejects.toEqual('network error');
+    });
+  });
+
+  describe('sendKindle', () => {
+    it('should resolve on success', async () => {
+      mockHttpClient.get.mockReturnValue(of({} as ApiReturn));
+
+      await expect(service.sendKindle(1, 'a@b.com')).resolves.toBeUndefined();
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/api/book/1/send/kindle?mail=a@b.com');
+    });
+
+    it('should reject when the request errors', async () => {
+      mockHttpClient.get.mockReturnValue(throwError(() => 'network error'));
+
+      await expect(service.sendKindle(1, 'a@b.com')).rejects.toEqual('network error');
+    });
+  });
+
+  describe('getEpubUrl', () => {
+    it('should resolve with a URL containing the token', async () => {
+      mockHttpClient.get.mockReturnValue(of({ id_token: 'tok123' } as ApiReturn));
+
+      const result = await service.getEpubUrl(1);
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/api/book/1/epub/url');
+      expect(result).toEqual('/api/book/1/epub?token=tok123');
+    });
+
+    it('should reject when response has no id_token', async () => {
+      mockHttpClient.get.mockReturnValue(of({} as ApiReturn));
+
+      await expect(service.getEpubUrl(1)).rejects.toEqual('Cannot get epub url');
+    });
+
+    it('should reject when the request errors', async () => {
+      mockHttpClient.get.mockReturnValue(throwError(() => 'network error'));
+
+      await expect(service.getEpubUrl(1)).rejects.toEqual('network error');
+    });
+  });
+
+  describe('getMobiUrl', () => {
+    it('should resolve with a URL containing the token', async () => {
+      mockHttpClient.get.mockReturnValue(of({ id_token: 'tok123' } as ApiReturn));
+
+      const result = await service.getMobiUrl(1);
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/api/book/1/mobi/url');
+      expect(result).toEqual('/api/book/1/mobi?token=tok123');
+    });
+
+    it('should reject when response has no id_token', async () => {
+      mockHttpClient.get.mockReturnValue(of({} as ApiReturn));
+
+      await expect(service.getMobiUrl(1)).rejects.toEqual('Cannot get mobi url');
+    });
+
+    it('should reject when the request errors', async () => {
+      mockHttpClient.get.mockReturnValue(throwError(() => 'network error'));
+
+      await expect(service.getMobiUrl(1)).rejects.toEqual('network error');
+    });
+  });
+
+  describe('updateReaderRating', () => {
+    const buildUser = (overrides: Partial<User> = {}): User =>
+      ({
+        id: 'user-1',
+        history: { lastConnection: new Date(), downloadedBooks: [], ratings: [] },
+        ...overrides,
+      }) as User;
+
+    it('should aggregate ratings from book history and flag the current user rating', () => {
+      const book = buildBook({
+        history: {
+          ratings: [
+            { user_id: 'user-1', rating: 4, date: new Date(), user_name: 'me' },
+            { user_id: 'user-2', rating: 2, date: new Date(), user_name: 'other' },
+          ],
+          downloads: [],
+        },
+      });
+      const user = buildUser();
+
+      const result = service.updateReaderRating(book, user);
+
+      expect(result.count).toBe(2);
+      expect(result.yourRating).toBe(4);
+      expect(result.rating).toBe(3);
+    });
+
+    it('should not fail when the user has no ratings history', () => {
+      const book = buildBook({
+        history: { ratings: [{ user_id: 'user-2', rating: 4, date: new Date(), user_name: 'other' }], downloads: [] },
+      });
+      const user = buildUser({ history: { lastConnection: new Date(), downloadedBooks: [], ratings: undefined as unknown as BookRating[] } });
+
+      const result = service.updateReaderRating(book, user);
+
+      expect(result.count).toBe(1);
+      expect(result.yourRating).toBe(0);
+      expect(result.rating).toBe(4);
+    });
+
+    it('should default to a 0 rating when there are no ratings at all', () => {
+      const book = buildBook({ history: { ratings: [], downloads: [] } });
+      const user = buildUser();
+
+      const result = service.updateReaderRating(book, user);
+
+      expect(result.count).toBe(0);
+      expect(result.rating).toBe(0);
+    });
+
+    it("should replace the book history rating with the user's own history rating for the same book", () => {
+      const book = buildBook({
+        book_id: 42,
+        history: {
+          ratings: [{ user_id: 'user-1', rating: 2, date: new Date(), user_name: 'me' }],
+          downloads: [],
+        },
+      });
+      const user = buildUser({
+        history: {
+          lastConnection: new Date(),
+          downloadedBooks: [],
+          ratings: [{ book_id: 42, rating: 5, date: new Date(), book_name: 'Some Book' }],
+        },
+      });
+
+      const result = service.updateReaderRating(book, user);
+
+      expect(result.count).toBe(1);
+      expect(result.yourRating).toBe(5);
+      expect(result.rating).toBe(5);
+    });
+
+    it('should ignore user history ratings for a different book', () => {
+      const book = buildBook({
+        book_id: 42,
+        history: { ratings: [{ user_id: 'user-2', rating: 3, date: new Date(), user_name: 'other' }], downloads: [] },
+      });
+      const user = buildUser({
+        history: {
+          lastConnection: new Date(),
+          downloadedBooks: [],
+          ratings: [{ book_id: 99, rating: 5, date: new Date(), book_name: 'Other Book' }],
+        },
+      });
+
+      const result = service.updateReaderRating(book, user);
+
+      expect(result.count).toBe(1);
+      expect(result.yourRating).toBe(0);
+      expect(result.rating).toBe(3);
+    });
+
+    it('should decrement the count without resetting yourRating when the matching entry has a falsy rating', () => {
+      const book = buildBook({
+        book_id: 42,
+        history: {
+          ratings: [{ user_id: 'user-1', rating: 4, date: new Date(), user_name: 'me' }],
+          downloads: [],
+        },
+      });
+      const user = buildUser({
+        history: {
+          lastConnection: new Date(),
+          downloadedBooks: [],
+          ratings: [{ book_id: 42, rating: 0, date: new Date(), book_name: 'Some Book' }],
+        },
+      });
+
+      const result = service.updateReaderRating(book, user);
+
+      // the falsy new rating removes the previous contribution from the sum/count,
+      // but the implementation does not reset yourRating in that case
+      expect(result.count).toBe(0);
+      expect(result.yourRating).toBe(4);
+      expect(result.rating).toBe(0);
+    });
+  });
+});

--- a/apps/frontend/src/app/core/util/window.service.spec.ts
+++ b/apps/frontend/src/app/core/util/window.service.spec.ts
@@ -1,0 +1,34 @@
+import { WindowService } from './window.service';
+
+describe('WindowService', () => {
+  it('should be created', () => {
+    expect(new WindowService()).toBeTruthy();
+  });
+
+  describe('createWindow', () => {
+    it('should return null when the url is null', () => {
+      expect(WindowService.createWindow(null as unknown as string)).toBeNull();
+    });
+
+    it('should open a centered popup window with the given url and name', () => {
+      const openSpy = jest.spyOn(window, 'open').mockReturnValue({} as Window);
+
+      const result = WindowService.createWindow('http://example.com', 'MyWindow', 400, 300);
+
+      expect(openSpy).toHaveBeenCalledWith('http://example.com', 'MyWindow', expect.stringContaining('width=400,height=300'));
+      expect(result).toBeDefined();
+
+      openSpy.mockRestore();
+    });
+
+    it('should apply default name, width and height when not provided', () => {
+      const openSpy = jest.spyOn(window, 'open').mockReturnValue({} as Window);
+
+      WindowService.createWindow('http://example.com');
+
+      expect(openSpy).toHaveBeenCalledWith('http://example.com', 'Window', expect.stringContaining('width=500,height=600'));
+
+      openSpy.mockRestore();
+    });
+  });
+});

--- a/libs/api-interfaces/src/lib/version.json
+++ b/libs/api-interfaces/src/lib/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.12.7",
+  "version": "0.12.8",
   "github_url": "https://github.com/bibulle/myCalibreServer",
   "name": "my-calibre-server",
   "copyright": "2016-2026 Bibulle"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "my-calibre-server",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "my-calibre-server",
-      "version": "0.12.7",
+      "version": "0.12.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16778,6 +16778,13 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
@@ -32632,6 +32639,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/test-exclude/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -32652,6 +32677,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/text-extensions": {

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "start:frontend": "nx serve frontend",
     "start:api": "nx serve api",
     "build": "nx build",
-    "test": "nx test",
+    "test": "nx run-many --target=test",
     "test:api": "nx test api",
     "test:frontend": "nx test frontend",
     "test:watch": "nx test --watch",
-    "test:coverage": "nx test --coverage",
+    "test:coverage": "nx run-many --target=test --coverage",
     "e2e": "./apps/frontend-e2e/scripts/run-e2e-tests.sh",
     "e2e:open": "./apps/frontend-e2e/scripts/run-e2e-tests.sh --open",
     "e2e:spec": "./apps/frontend-e2e/scripts/run-e2e-tests.sh --spec",
@@ -74,6 +74,12 @@
     "ajv@^6": "6.14.0",
     "ajv@^8": "8.18.0",
     "minimatch": "10.2.4",
+    "test-exclude": {
+      "minimatch": "^3.1.2",
+      "glob": {
+        "minimatch": "^3.1.2"
+      }
+    },
     "@tootallnate/once": "3.0.1",
     "koa": "3.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-calibre-server",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Added missing unit tests covering critical paths, edge cases and error scenarios across frontend and backend, per the testing requirements in `CLAUDE.md`.
- **Frontend**: `book.service.ts` (was ~4% covered, had no spec file at all), `user.service.ts` (auth error paths, `_doPost`/`_doGet` branches, the OAuth popup polling flow, `_parseQueryString`), `book-card.component.ts`, `window.service.ts` (no spec file before).
- **Backend**: `cache.service.ts` (13%, no spec file before), `mail.service.ts` (32%, no spec file before, mocks `nodemailer`), `books.service.ts` (thumbnail/sprite generation, real `sharp` image processing, download error branches), `series.service.ts` (sprite generation/overlay logic), `users.service.ts` (merge logic, rating/download sorting, `getBearerUser`), `calibre-db1.service.ts` (`getAllSeries/Authors/Tags` grouping+sorting, SQL error branches, `fillBooksFromUser`), `authentication.controller.ts` (admin unlink flows for Facebook, mirroring existing Google coverage).
- Fixed two tooling bugs found while working through this:
  1. The global npm `minimatch` security override (`10.2.4`) was breaking coverage instrumentation for the frontend (`minimatch is not a function`) because `test-exclude`/`glob@7` internally need the old callable-function API. Scoped the override so only that dev-only, coverage-only dependency chain keeps the compatible `^3.1.2` version — no change to the effective security posture since that chain never ships to production.
  2. `npm run test` / `npm run test:coverage` were silently only running the frontend project, because `nx test` with no project name resolves to `nx.json`'s `defaultProject: "frontend"`. Switched both scripts to `nx run-many --target=test` so they actually run both projects, matching what they've always claimed to do.
- Updated `README.md`'s testing section to reflect the corrected `npm run test` / `npm run test:coverage` behavior.

**Coverage** (statements): frontend ~71% → ~98%, backend ~62% → ~90% (the one remaining low-coverage backend file, `my-calibre-db.service.ts`, needs a real MongoDB instance to test and isn't reachable in this sandboxed CI environment — pre-existing, unrelated to this PR).

**Note**: one latent bug was found and documented (not fixed, since it's out of scope for a test-only change): `UsersService.getBearerUser` throws a raw `TypeError` instead of the intended `"No token"` error when a request has a `headers` object with no `authorization` key. See the added test's comment in `users.service.spec.ts`.

## Test plan
- [x] `npm run test` (frontend + backend) — all green except the pre-existing MongoDB-dependent suite (`my-calibre-db.service.spec.ts`), which requires MongoDB unavailable in this environment.
- [x] `npm run start:api` — starts and serves all routes correctly.
- [x] `npm run start:frontend` — starts and serves (HTTP 200).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_013ZabhpRRZUYf5Q1soRPpn4

---
_Generated by [Claude Code](https://claude.ai/code/session_013ZabhpRRZUYf5Q1soRPpn4)_