### PR TITLE
docs: update Angular 22 / TypeScript 6 blocker status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,14 +32,18 @@
 > potentiellement du code fonctionnel et sont traitées comme des chantiers
 > séparés nécessitant un accord explicite préalable.
 >
-> **Angular 22 est bloqué en amont** : `@nx/angular@23.0.1` plafonne son peer
-> dependency `@angular-devkit/build-angular` (et `@angular/build`) à `< 22.0.0`.
-> Nx n'a donc pas encore ajouté le support d'Angular 22 ; la montée de version
-> ne pourra être tentée qu'une fois une release `@nx/angular` compatible publiée.
+> **Angular 22 est bloqué en amont** : `@nx/angular@23.0.1` (dernière version **stable**)
+> plafonne son peer dependency `@angular-devkit/build-angular` (et `@angular/build`) à
+> `< 22.0.0`. Le support d'Angular 22 existe déjà côté Nx sous forme de builds **canary**
+> (`@nx/angular@23.1.0-canary.*`, dont le peer range monte à `< 23.0.0`), mais aucune
+> release stable `23.1.0` n'est publiée à ce jour (vérifié le 2026-07-05) — décision prise
+> de ne pas dépendre d'un canary en production. La montée de version ne sera retentée
+> qu'une fois une release stable `@nx/angular` compatible publiée.
 >
-> **TypeScript 6 est bloqué pour la même raison** : `@angular-devkit/build-angular@21.2.18`
-> plafonne son peer dependency `typescript` à `< 6.0` (alors que `@angular/compiler-cli`
-> seul autoriserait `< 6.1`). Bloqué tant qu'Angular 22 (et son outillage de build) n'est pas disponible.
+> **TypeScript 6 est couplé à Angular 22, pas un chantier séparé** : `@angular-devkit/build-angular@22.x`
+> (dernière version) exige désormais `typescript >=6.0 <6.1` (le peer `< 6.0` de la 21.x est devenu un
+> plancher `>= 6.0` en 22.x) — impossible de monter TypeScript 6 sans monter Angular 22 en même temps,
+> ni l'inverse. Les deux montées sont donc bloquées ensemble par le même verrou `@nx/angular`.
 
 ## Notes importantes
 


### PR DESCRIPTION
## Summary

Following up on the dependency-upgrade session, investigated whether Angular 22 / Nx / TypeScript 6 could be unblocked:

- `@nx/angular`'s stable release (23.0.1) still caps `@angular-devkit/build-angular` (and `@angular/build`) at `< 22.0.0`.
- A canary line already exists (`@nx/angular@23.1.0-canary.*`) with the peer range raised to `< 23.0.0`, i.e. Angular 22 support — but no stable `23.1.0` release yet (checked 2026-07-05). Decision: don't depend on a canary build in production; keep waiting for a stable release.
- Also discovered TypeScript 6 is no longer an independent blocker: the latest `@angular-devkit/build-angular` requires `typescript >=6.0 <6.1`, so Angular 22 and TypeScript 6 must be upgraded together — both are gated by the same `@nx/angular` constraint.

No code changes, docs-only update to `AGENTS.md` to keep the blocker status accurate for the next attempt.

## Test plan

- Docs-only change, no test impact. `AGENTS.md` content reviewed for accuracy against current npm registry state.

https://claude.ai/code/session_01FQ2Q85PHE36BPJHspvKq92

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQ2Q85PHE36BPJHspvKq92)_