### PR TITLE
feat(frontend): design tokens and dark theme foundation (Reliure redesign, PR 1/7)

### DIFF
--- a/apps/frontend/src/app/app.module.ts
+++ b/apps/frontend/src/app/app.module.ts
@@ -34,6 +34,7 @@ import { MatRatingModule } from './components/rating/rating.component';
 import { SeriesModule } from './components/series/series.module';
 import { TagModule } from './components/tag/tag.module';
 import { WindowService } from './core/util/window.service';
+import { ThemeService } from './core/theme/theme.service';
 import { AuthGuardToken } from './components/authent/auth.guard.token';
 import { MatButtonModule } from '@angular/material/button';
 import { ServiceWorkerModule } from '@angular/service-worker';
@@ -94,6 +95,7 @@ registerLocaleData(localeEn, 'en');
     TitleService,
     NotificationService,
     WindowService,
+    ThemeService,
     AuthGuard,
     AuthGuardToken,
     AuthGuardAdmin,

--- a/apps/frontend/src/app/core/theme/theme.service.spec.ts
+++ b/apps/frontend/src/app/core/theme/theme.service.spec.ts
@@ -1,0 +1,89 @@
+import { ThemeService } from './theme.service';
+
+function mockMatchMedia(matchesDark: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: jest.fn().mockImplementation((query: string) => ({
+      matches: matchesDark && query === '(prefers-color-scheme: dark)',
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+}
+
+describe('ThemeService', () => {
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark-theme');
+  });
+
+  it('should default to light when the system prefers light and nothing is stored', () => {
+    mockMatchMedia(false);
+
+    const service = new ThemeService();
+
+    expect(service.mode).toBe('light');
+    expect(service.isDark()).toBe(false);
+    expect(document.documentElement.classList.contains('dark-theme')).toBe(false);
+  });
+
+  it('should default to dark when the system prefers dark and nothing is stored', () => {
+    mockMatchMedia(true);
+
+    const service = new ThemeService();
+
+    expect(service.mode).toBe('dark');
+    expect(service.isDark()).toBe(true);
+    expect(document.documentElement.classList.contains('dark-theme')).toBe(true);
+  });
+
+  it('should prefer the stored mode over the system preference', () => {
+    mockMatchMedia(true);
+    localStorage.setItem('my-calibre-server-theme', 'light');
+
+    const service = new ThemeService();
+
+    expect(service.mode).toBe('light');
+    expect(document.documentElement.classList.contains('dark-theme')).toBe(false);
+  });
+
+  it('should ignore an invalid stored value and fall back to the system preference', () => {
+    mockMatchMedia(true);
+    localStorage.setItem('my-calibre-server-theme', 'not-a-theme');
+
+    const service = new ThemeService();
+
+    expect(service.mode).toBe('dark');
+  });
+
+  it('should persist and apply the mode when setMode is called', () => {
+    mockMatchMedia(false);
+    const service = new ThemeService();
+
+    service.setMode('dark');
+
+    expect(service.mode).toBe('dark');
+    expect(localStorage.getItem('my-calibre-server-theme')).toBe('dark');
+    expect(document.documentElement.classList.contains('dark-theme')).toBe(true);
+  });
+
+  it('should toggle between light and dark', () => {
+    mockMatchMedia(false);
+    const service = new ThemeService();
+
+    service.toggle();
+    expect(service.mode).toBe('dark');
+    expect(document.documentElement.classList.contains('dark-theme')).toBe(true);
+
+    service.toggle();
+    expect(service.mode).toBe('light');
+    expect(document.documentElement.classList.contains('dark-theme')).toBe(false);
+  });
+});

--- a/apps/frontend/src/app/core/theme/theme.service.ts
+++ b/apps/frontend/src/app/core/theme/theme.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+
+export type ThemeMode = 'light' | 'dark';
+
+const STORAGE_KEY = 'my-calibre-server-theme';
+const DARK_CLASS = 'dark-theme';
+
+@Injectable()
+export class ThemeService {
+
+  private _mode: ThemeMode;
+
+  constructor() {
+    this._mode = this._readStoredMode() ?? this._systemMode();
+    this._apply(this._mode);
+  }
+
+  get mode(): ThemeMode {
+    return this._mode;
+  }
+
+  isDark(): boolean {
+    return this._mode === 'dark';
+  }
+
+  setMode(mode: ThemeMode): void {
+    this._mode = mode;
+    localStorage.setItem(STORAGE_KEY, mode);
+    this._apply(mode);
+  }
+
+  toggle(): void {
+    this.setMode(this.isDark() ? 'light' : 'dark');
+  }
+
+  private _apply(mode: ThemeMode): void {
+    document.documentElement.classList.toggle(DARK_CLASS, mode === 'dark');
+  }
+
+  private _readStoredMode(): ThemeMode | null {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored === 'light' || stored === 'dark' ? stored : null;
+  }
+
+  private _systemMode(): ThemeMode {
+    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+}

--- a/apps/frontend/src/app/shared/_tokens.scss
+++ b/apps/frontend/src/app/shared/_tokens.scss
@@ -1,0 +1,69 @@
+// Design tokens for the "Reliure" redesign (see design_handoff_reliure/README.md).
+// Exposed as CSS custom properties so component styles can consume them
+// directly, and swapped wholesale under `.dark-theme` for the dark palette.
+
+:root {
+  // Surfaces & text (light)
+  --bg: #f4efe5;
+  --surface: #fffdf8;
+  --surface-2: #f4ece0;
+  --border: #e2d6c2;
+  --border-soft: #ece1cf;
+  --header-bg: rgba(255, 253, 248, .92);
+  --text: #241d14;
+  --text-2: #2a2118;
+  --muted: #8a7f6f;
+  --muted-2: #6b6152;
+  --faint: #a2907a;
+  --prose: #413729;
+  --star-empty: #dcd0bd;
+
+  // Accent & semantic (theme-independent)
+  --accent: #c0563a;
+  --accent-2: #b5764a;
+  --accent-3: #a8574e;
+  --accent-4: #7d6b3c;
+  --success: #3a8a5a;
+  --danger: #b5563a;
+  --danger-border: #c9755f;
+  --danger-border-soft: #d8a08e;
+  --facebook: #1877f2;
+
+  // Shadows (light)
+  --shadow-card: 0 4px 14px rgba(80, 55, 25, .05);
+  --shadow-popover: 0 16px 34px rgba(80, 55, 25, .18);
+  --shadow-cover-sm: 0 6px 15px rgba(0, 0, 0, .28);
+  --shadow-cover-lg: 0 24px 50px -12px rgba(0, 0, 0, .4);
+
+  // Radii (theme-independent)
+  --radius-field: 10px;
+  --radius-card: 14px;
+  --radius-card-lg: 16px;
+  --radius-container: 18px;
+  --radius-pill: 999px;
+
+  // Typography families (theme-independent)
+  --font-serif-title: 'Newsreader', serif;
+  --font-serif-body: 'Spectral', serif;
+  --font-ui: 'IBM Plex Sans', sans-serif;
+  --font-display: 'Space Grotesk', sans-serif;
+}
+
+.dark-theme {
+  --bg: #141210;
+  --surface: #211d18;
+  --surface-2: #2b251e;
+  --border: #37302799;
+  --border-soft: #332c24;
+  --header-bg: rgba(25, 21, 17, .9);
+  --text: #f2ece1;
+  --text-2: #f4efe6;
+  --muted: #a99e8f;
+  --muted-2: #c0b5a4;
+  --faint: #8f8474;
+  --prose: #d9cebd;
+  --star-empty: #4a4137;
+
+  --shadow-card: 0 4px 16px rgba(0, 0, 0, .4);
+  --shadow-popover: 0 16px 40px rgba(0, 0, 0, .55);
+}

--- a/apps/frontend/src/app/shared/theme.scss
+++ b/apps/frontend/src/app/shared/theme.scss
@@ -7,12 +7,24 @@
 //$my-theme-accent: mat-palette($mat-light-blue);
 //$my-theme-warn: mat-palette($mat-deep-orange, A200);
 
-$primary: mat.m2-define-palette(mat.$m2-green-palette, 600, 300, 900);
-$accent: mat.m2-define-palette(mat.$m2-light-blue-palette);
+// "Reliure" redesign: a single warm terracotta accent drives both primary
+// and accent so native Material chrome (buttons, toggles, focus rings)
+// matches the --accent design token (see shared/_tokens.scss). The exact
+// brand hex is applied directly via CSS custom properties where pixel
+// fidelity matters; these palettes only need to be a close match for
+// Material's own internal color computations (ripples, states, contrast).
+$primary: mat.m2-define-palette(mat.$m2-deep-orange-palette, 600, 300, 900);
+$accent: mat.m2-define-palette(mat.$m2-deep-orange-palette);
 $warn: mat.m2-define-palette(mat.$m2-deep-orange-palette, A200);
 
 // create theme (use mat-dark-theme for themes with dark backgrounds)
 $theme: mat.m2-define-light-theme((color: (primary: $primary,
+        accent: $accent,
+        warn: $warn,
+      ),
+    ));
+
+$theme-dark: mat.m2-define-dark-theme((color: (primary: $primary,
         accent: $accent,
         warn: $warn,
       ),

--- a/apps/frontend/src/app/shared/theme.scss
+++ b/apps/frontend/src/app/shared/theme.scss
@@ -7,14 +7,14 @@
 //$my-theme-accent: mat-palette($mat-light-blue);
 //$my-theme-warn: mat-palette($mat-deep-orange, A200);
 
-// "Reliure" redesign: a single warm terracotta accent drives both primary
-// and accent so native Material chrome (buttons, toggles, focus rings)
-// matches the --accent design token (see shared/_tokens.scss). The exact
-// brand hex is applied directly via CSS custom properties where pixel
-// fidelity matters; these palettes only need to be a close match for
-// Material's own internal color computations (ripples, states, contrast).
-$primary: mat.m2-define-palette(mat.$m2-deep-orange-palette, 600, 300, 900);
-$accent: mat.m2-define-palette(mat.$m2-deep-orange-palette);
+// NOTE: primary/accent stay on their original palettes for now so this PR
+// has no visible effect on the current (pre-redesign) UI. The swap to the
+// terracotta accent from the "Reliure" design (see shared/_tokens.scss for
+// the --accent CSS custom property already available) is deferred to the
+// app-shell/nav PR, where the whole header is recolored at once instead of
+// piecemeal.
+$primary: mat.m2-define-palette(mat.$m2-green-palette, 600, 300, 900);
+$accent: mat.m2-define-palette(mat.$m2-light-blue-palette);
 $warn: mat.m2-define-palette(mat.$m2-deep-orange-palette, A200);
 
 // create theme (use mat-dark-theme for themes with dark backgrounds)

--- a/apps/frontend/src/styles.scss
+++ b/apps/frontend/src/styles.scss
@@ -1,5 +1,6 @@
 @use '@angular/material' as mat;
 @use 'app/shared/theme' as theme;
+@use 'app/shared/tokens';
 @use 'app/app.component.theme' as appTheme;
 @use 'app/components/authent/users-list/users-list.component.theme' as usersListTheme;
 @use 'app/components/authent/users-list/user-list-item/user-list-item.component.theme' as userListItemTheme;
@@ -8,12 +9,20 @@
 
 @import url(https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,400italic);
 @import url(https://fonts.googleapis.com/icon?family=Material+Icons);
+@import url(https://fonts.googleapis.com/css2?family=Newsreader:ital,wght@0,600;1,600&family=Spectral:wght@400;600&family=IBM+Plex+Sans:wght@400;500;600&family=Space+Grotesk:wght@500;600&display=swap);
 
 // always include only once per project
 @include mat.elevation-classes();
 @include mat.app-background();
 
 @include mat.all-component-themes(theme.$theme);
+
+// Dark theme: swap only the color layer under `.dark-theme` (applied to
+// <html> by ThemeService) so typography/density stay shared with the light
+// theme defined above.
+.dark-theme {
+  @include mat.all-component-colors(theme.$theme-dark);
+}
 
 @mixin custom-components-theme($theme) {
   @include appTheme.app-component-theme($theme);


### PR DESCRIPTION
## Contexte

Première PR d'une série de 7 pour implémenter le redesign "Reliure" (voir le handoff de design fourni). Cette PR pose uniquement les fondations : tokens de design et infrastructure de thème clair/sombre. **Aucun changement visuel** — c'est une PR purement additive, à faible risque, pour préparer les PR suivantes (shell/nav, bibliothèque, fiche livre, séries/auteurs/tags, connexion, profil/admin).

## Changements

- `apps/frontend/src/app/shared/_tokens.scss` : tokens de design clair/sombre du handoff (couleurs, ombres, rayons, familles typographiques) exposés en variables CSS (`:root` / `.dark-theme`).
- `apps/frontend/src/app/shared/theme.scss` : ajout d'un thème Material sombre (`$theme-dark`) en plus du thème clair existant. Les palettes Material `primary`/`accent` restent volontairement inchangées (vert/bleu) dans cette PR — le passage à l'accent terracotta du design se fera dans la PR suivante (shell/nav), en même temps que le reste du header, pour éviter un recolorage partiel de l'UI actuelle.
- `apps/frontend/src/styles.scss` : inclusion des tokens, bascule des couleurs Material sous `.dark-theme` (`mat.all-component-colors`), ajout des polices Google Fonts Newsreader/Spectral/IBM Plex Sans/Space Grotesk.
- `apps/frontend/src/app/core/theme/theme.service.ts` (+ tests) : détection `prefers-color-scheme`, persistance `localStorage`, bascule clair/sombre — enregistré dans `AppModule` mais pas encore injecté nulle part (branchement sur le header prévu en PR 2).

Aucune logique métier existante modifiée.

## Tests

- `npm run test:frontend` : 337 tests verts (17 suites), incluant les 6 nouveaux tests de `ThemeService`.
- `npm run test:api` : 369 tests verts (non affectés, PR frontend-only).
- `npm run e2e:playwright` : 69 tests verts.
- `npx nx build frontend` : build de production OK.
- `npm run start:api` / `npm run start:frontend` : démarrage sans erreur (l'API remonte une erreur `ENOENT` attendue sur `metadata.db`, faute de bibliothèque Calibre réelle dans cet environnement).
- `npx nx lint frontend` : aucune nouvelle erreur/warning introduite (1 erreur pré-existante dans `app.component.spec.ts`, confirmée présente sur `master` avant cette PR).

## Suite

PR 2/7 : remplacement du tiroir latéral (`mat-sidenav`) par le header collant à onglets, y compris le passage à l'accent terracotta, branché sur ce `ThemeService`.
