### PR TITLE
test: add browser-driven UI e2e coverage for the "Reliure" redesign

### DIFF
--- a/apps/frontend-e2e-playwright/README.md
+++ b/apps/frontend-e2e-playwright/README.md
@@ -9,6 +9,38 @@ API and frontend dev servers and covers:
 - Books, series, authors, and tags browsing, search, filtering, sorting
 - Book ratings
 
+Most of the above (`app.spec.ts`, `authentication.spec.ts`, `books.spec.ts`,
+`series-authors-tags.spec.ts`, `api-readonly.spec.ts`) drive the API directly
+over HTTP rather than through the browser UI. The `ui-*.spec.ts` files
+complement that with real, browser-driven interaction through the rendered
+"Reliure" UI:
+
+- `ui-auth.spec.ts` - login/signup/logout through the actual forms
+- `ui-navigation.spec.ts` - header nav tabs, search box, theme toggle, sort menu
+- `ui-book-detail.spec.ts` - opening a book, rating it, author/tag pill links,
+  EPUB/MOBI/Kindle download affordances
+- `ui-library-lists.spec.ts` - series volumes, author accordion, tag filtering
+- `ui-profile.spec.ts` - identity banner, admin-only button, linked-accounts
+  buttons, password field validation states
+- `ui-admin.spec.ts` - access control, sorting, the expandable read-only
+  summary row, merge selection toggle, and a dedicated `deletableuser`
+  fixture's full lifecycle (profile edit, Kindle address, password change,
+  admin toggle, delete)
+- `ui-news-home.spec.ts` - grouped news/home sections and opening a book from
+  a row
+
+The `ui-admin.spec.ts` lifecycle test intentionally does not click the admin
+"Reset password" button (it emails via a real, unconfigured SMTP dependency)
+or the OAuth "Connect" buttons (they open a real external popup with no
+configured OAuth credentials in this environment) - only their presence is
+checked. It also doesn't complete a real user merge, only the select/unselect
+toggle. It types the firstname field but doesn't assert that the debounced
+autosave commits: `UserService` polls `checkAuthent()` every 3 seconds for the
+lifetime of the page and unconditionally rebuilds the in-memory user object
+from the JWT, which can race the 500ms autosave debounce and drop an in-flight
+edit before it reaches the backend - a pre-existing timing issue in the app,
+out of scope for this test-coverage change.
+
 ## No MongoDB required, anywhere
 
 The API's `mongodb` driver is swapped for a small in-memory stub (see

--- a/apps/frontend-e2e-playwright/mongo-stub/fixtures.js
+++ b/apps/frontend-e2e-playwright/mongo-stub/fixtures.js
@@ -23,6 +23,7 @@ function hashPassword(password, salt) {
 const TEST_PASSWORD = 'password123';
 const testUserSalt = 'e2e-test-salt-user';
 const adminUserSalt = 'e2e-test-salt-admin';
+const deletableUserSalt = 'e2e-test-salt-deletable';
 
 const testUsers = [
   {
@@ -75,6 +76,27 @@ const testUsers = [
           date: new Date('2024-01-05T10:00:00.000Z'),
         },
       ],
+    },
+  },
+  {
+    // Dedicated throwaway account for e2e tests exercising destructive admin
+    // actions (reset password, delete) - never used for login elsewhere, so
+    // mutating/removing it can't break other tests.
+    id: 'e2e-user-3',
+    local: {
+      username: 'deletableuser',
+      salt: deletableUserSalt,
+      hashedPassword: hashPassword(TEST_PASSWORD, deletableUserSalt),
+      isAdmin: false,
+      email: 'deletable@example.com',
+    },
+    email: 'deletable@example.com',
+    roles: ['user'],
+    created: new Date('2024-02-01T00:00:00.000Z'),
+    updated: new Date('2024-02-01T00:00:00.000Z'),
+    history: {
+      downloadedBooks: [],
+      ratings: [],
     },
   },
 ];

--- a/apps/frontend-e2e-playwright/tests/helpers.ts
+++ b/apps/frontend-e2e-playwright/tests/helpers.ts
@@ -1,9 +1,22 @@
-import { APIRequestContext } from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
 
 export const apiUrl = 'http://localhost:3333/api';
 
 export const testUser = { username: 'testuser', password: 'password123' };
 export const adminUser = { username: 'adminuser', password: 'password123' };
+export const deletableUser = { username: 'deletableuser', password: 'password123' };
+
+/**
+ * Log in through the real login form (not the API) and wait for the
+ * post-login redirect to /home, for UI-driven e2e tests.
+ */
+export async function loginViaUi(page: Page, username: string, password: string): Promise<void> {
+  await page.goto('/login');
+  await page.locator('#login-username').fill(username);
+  await page.locator('#login-password').fill(password);
+  await page.locator('.submit-btn').click();
+  await page.waitForURL(/\/home/);
+}
 
 export async function login(request: APIRequestContext, username: string, password: string): Promise<string> {
   const response = await request.post(`${apiUrl}/authent/login`, {

--- a/apps/frontend-e2e-playwright/tests/ui-admin.spec.ts
+++ b/apps/frontend-e2e-playwright/tests/ui-admin.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from '@playwright/test';
+import { loginViaUi, testUser, adminUser, deletableUser } from './helpers';
+
+/**
+ * Browser-driven admin users table (PR7): access control, sorting, the
+ * expandable read-only detail row, and the merge select/unselect toggle.
+ *
+ * The one test at the bottom drives the *entire* lifecycle of the
+ * dedicated `deletableuser` fixture (inline profile edit -> Kindle address
+ * add/remove -> inline password change -> admin toggle -> delete) in a
+ * single `test()` block, so those steps always run in that order
+ * regardless of Playwright's fullyParallel scheduling - splitting them
+ * across separate tests/files would risk one running before another
+ * (e.g. the account being deleted before the password-change test logs
+ * into it).
+ */
+test.describe('UI - Admin', () => {
+  test('should redirect a non-admin user away from the users page', async ({ page }) => {
+    await loginViaUi(page, testUser.username, testUser.password);
+    await page.goto('/users');
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('should sort the users table by username', async ({ page }) => {
+    await loginViaUi(page, adminUser.username, adminUser.password);
+    await page.goto('/users');
+
+    await page.locator('.col-username').click();
+    const firstUsernameAsc = await page.locator('.user-card .username').first().textContent();
+
+    await page.locator('.col-username').click();
+    const firstUsernameDesc = await page.locator('.user-card .username').first().textContent();
+
+    expect(firstUsernameAsc).not.toEqual(firstUsernameDesc);
+  });
+
+  test('should expand a row to show the read-only account/activity summary', async ({ page }) => {
+    await loginViaUi(page, adminUser.username, adminUser.password);
+    await page.goto('/users');
+
+    const row = page.locator('.user-card', { hasText: testUser.username });
+    await row.locator('.chevron').click();
+
+    await expect(row.locator('.detail-box')).toBeVisible();
+    await expect(row.locator('.detail-label').first()).toBeVisible();
+    await expect(row.locator('.pill-outline', { hasText: /reset/i })).toBeVisible();
+  });
+
+  test('should toggle merge selection on and off without completing a merge', async ({ page }) => {
+    await loginViaUi(page, adminUser.username, adminUser.password);
+    await page.goto('/users');
+
+    const row = page.locator('.user-card', { hasText: testUser.username });
+    await row.locator('.chevron').click();
+
+    await row.locator('.merge-select').click();
+    await expect(row).toHaveClass(/user-selected/);
+
+    await row.locator('.merge-unselect').click();
+    await expect(row).not.toHaveClass(/user-selected/);
+  });
+
+  test('deletable user: profile edit, kindle address, password change, admin toggle, then delete', async ({ page }) => {
+    // This test drives two logins and many sequential UI steps end-to-end;
+    // the default 30s test timeout is too tight for that under load.
+    test.setTimeout(90000);
+
+    // --- Inline profile edit (firstname/lastname) ---
+    await loginViaUi(page, deletableUser.username, deletableUser.password);
+    await page.goto('/profile');
+
+    // Only check that typing reaches the field itself here, not that the
+    // debounced autosave commits: UserService's periodic checkAuthent() (every
+    // 3s, for the lifetime of the page) unconditionally rebuilds the in-memory
+    // user object from the JWT and can race the 500ms autosave debounce,
+    // dropping an in-flight edit before it's ever sent to the backend - a
+    // pre-existing timing issue in the app, out of scope for this e2e-coverage
+    // change (flagged separately).
+    const firstNameInput = page.locator('.account-fields input').nth(1);
+    await firstNameInput.click();
+    await firstNameInput.pressSequentially('Del');
+    await expect(firstNameInput).toHaveValue('Del');
+    await firstNameInput.blur();
+
+    // --- Kindle address add/remove ---
+    await page.locator('.kindle-add-row input').fill('kindle-e2e@example.com');
+    await page.locator('.round-btn-accent').click();
+    await expect(page.locator('.kindle-row', { hasText: 'kindle-e2e@example.com' })).toBeVisible();
+
+    await page.locator('.kindle-row', { hasText: 'kindle-e2e@example.com' }).locator('.round-btn').click();
+    await expect(page.locator('.kindle-row', { hasText: 'kindle-e2e@example.com' })).toHaveCount(0);
+
+    // --- Inline password change ---
+    await page.locator('#changepw-password1').pressSequentially('newpassword1');
+    await page.locator('#changepw-password2').pressSequentially('newpassword1');
+    await expect(page.locator('.hint-ok')).toBeVisible();
+    await page.locator('button[type=submit]', { hasText: /password|mot de passe/i }).click();
+    await expect(page).toHaveURL(/\/profile/);
+
+    await page.locator('.identity-actions .pill-outline').click();
+    await page.waitForTimeout(300);
+
+    // --- Admin toggle, then delete, from the admin table ---
+    await loginViaUi(page, adminUser.username, adminUser.password);
+    await page.goto('/users');
+
+    const row = page.locator('.user-card', { hasText: deletableUser.username });
+    await expect(row.locator('mat-slide-toggle')).not.toHaveClass(/mat-mdc-slide-toggle-checked/);
+    await row.locator('mat-slide-toggle button').click();
+    await expect(row.locator('mat-slide-toggle')).toHaveClass(/mat-mdc-slide-toggle-checked/);
+
+    await row.locator('.chevron').click();
+    await row.locator('.pill-danger').click();
+    await expect(page.locator('.user-card', { hasText: deletableUser.username })).toHaveCount(0);
+  });
+});

--- a/apps/frontend-e2e-playwright/tests/ui-auth.spec.ts
+++ b/apps/frontend-e2e-playwright/tests/ui-auth.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { testUser, adminUser } from './helpers';
+
+/**
+ * Browser-driven authentication flows (login/signup/logout forms), as
+ * opposed to authentication.spec.ts which only exercises the API directly.
+ */
+test.describe('UI - Authentication', () => {
+  test('should log in through the form and land on the home page', async ({ page }) => {
+    await page.goto('/login');
+    await page.locator('#login-username').fill(testUser.username);
+    await page.locator('#login-password').fill(testUser.password);
+    await page.locator('.submit-btn').click();
+
+    await expect(page).toHaveURL(/\/home/);
+    await expect(page.locator('.nav-tabs')).toBeVisible();
+  });
+
+  test('should show an error and stay on the login page for wrong credentials', async ({ page }) => {
+    await page.goto('/login');
+    await page.locator('#login-username').fill(testUser.username);
+    await page.locator('#login-password').fill('not-the-right-password');
+    await page.locator('.submit-btn').click();
+
+    await expect(page.getByText(/wrong/i)).toBeVisible();
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('should navigate to signup via the in-app link and create a new account', async ({ page }) => {
+    await page.goto('/login');
+    await page.locator('.switch-auth .link').click();
+    await expect(page).toHaveURL(/\/signup/);
+
+    const uniqueUsername = `e2enew${Date.now()}`;
+    await page.locator('#signup-username').fill(uniqueUsername);
+    await page.locator('#signup-password').fill('password123');
+    await page.locator('#signup-firstname').fill('New');
+    await page.locator('#signup-lastname').fill('User');
+    await page.locator('#signup-email').fill(`${uniqueUsername}@example.com`);
+    await page.locator('.submit-btn').click();
+
+    await expect(page).toHaveURL(/\/home/);
+    await expect(page.locator('.nav-tabs')).toBeVisible();
+  });
+
+  test('should log out from the profile page and require login again', async ({ page }) => {
+    await page.goto('/login');
+    await page.locator('#login-username').fill(adminUser.username);
+    await page.locator('#login-password').fill(adminUser.password);
+    await page.locator('.submit-btn').click();
+    await expect(page).toHaveURL(/\/home/);
+
+    await page.locator('my-calibre-server-profile-button .avatar').click();
+    await expect(page).toHaveURL(/\/profile/);
+
+    await page.locator('.identity-actions .pill-outline').click();
+    await page.waitForTimeout(300);
+
+    await page.goto('/profile');
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/apps/frontend-e2e-playwright/tests/ui-book-detail.spec.ts
+++ b/apps/frontend-e2e-playwright/tests/ui-book-detail.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+import { loginViaUi, testUser } from './helpers';
+
+/**
+ * Browser-driven book detail page (PR4): opening a book, rating it,
+ * following series/author/tag links, and the download/kindle affordances
+ * (only present when the opened book actually has EPUB/MOBI data).
+ */
+test.describe('UI - Book detail', () => {
+  test('should open a book from the library and show its details', async ({ page }) => {
+    await loginViaUi(page, testUser.username, testUser.password);
+    await page.locator('.nav-tabs a[href="/books"]').click();
+    await expect(page).toHaveURL(/\/books/);
+
+    await page.locator('.rl-card').first().click();
+    await expect(page).toHaveURL(/\/book\/\d+/);
+
+    await expect(page.locator('.rl-info h1')).toBeVisible();
+    await expect(page.locator('.meta-row .author-pill').first()).toBeVisible();
+  });
+
+  test('should rate a book and get a confirmation', async ({ page }) => {
+    await loginViaUi(page, testUser.username, testUser.password);
+    await page.locator('.nav-tabs a[href="/books"]').click();
+    await page.locator('.rl-card').first().click();
+    await expect(page).toHaveURL(/\/book\/\d+/);
+
+    await page.locator('#star_2').click();
+
+    await expect(page.locator('.mat-mdc-snack-bar-label').first()).toBeVisible();
+  });
+
+  test('should follow an author pill back into the authors page', async ({ page }) => {
+    await loginViaUi(page, testUser.username, testUser.password);
+    await page.locator('.nav-tabs a[href="/books"]').click();
+    await page.locator('.rl-card').first().click();
+    await expect(page).toHaveURL(/\/book\/\d+/);
+
+    await page.locator('.meta-row .author-pill').first().click();
+    await expect(page).toHaveURL(/\/authors\?/);
+  });
+
+  test('should follow a tag pill into the tags page', async ({ page }) => {
+    await loginViaUi(page, testUser.username, testUser.password);
+    await page.locator('.nav-tabs a[href="/books"]').click();
+    await page.locator('.rl-card').first().click();
+    await expect(page).toHaveURL(/\/book\/\d+/);
+
+    const tagPill = page.locator('.tags-content .tag-pill').first();
+    if (await tagPill.count()) {
+      await tagPill.click();
+      await expect(page).toHaveURL(/\/tags\?/);
+    }
+  });
+
+  test('should offer EPUB/MOBI downloads and the Kindle dialog when the book has files', async ({ page }) => {
+    await loginViaUi(page, testUser.username, testUser.password);
+    await page.locator('.nav-tabs a[href="/books"]').click();
+    await page.locator('.rl-card').first().click();
+    await expect(page).toHaveURL(/\/book\/\d+/);
+
+    const kindleBtn = page.locator('.downloads .download-btn', { hasText: /kindle/i });
+    if (await kindleBtn.count()) {
+      await kindleBtn.click();
+      await expect(page.locator('mat-dialog-container')).toBeVisible();
+      await page.locator('mat-dialog-container button', { hasText: /cancel/i }).click();
+      await expect(page.locator('mat-dialog-container')).toHaveCount(0);
+    }
+  });
+});

--- a/apps/frontend-e2e-playwright/tests/ui-library-lists.spec.ts
+++ b/apps/frontend-e2e-playwright/tests/ui-library-lists.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+import { loginViaUi, testUser } from './helpers';
+
+/**
+ * Browser-driven series/authors/tags pages (PR5): series volumes, the
+ * author accordion, and the tag cloud's select/clear-filter interaction.
+ */
+test.describe('UI - Series, authors and tags', () => {
+  test('should show series with clickable volumes that open the book page', async ({ page }) => {
+    await loginViaUi(page, testUser.username, testUser.password);
+    await page.locator('.nav-tabs a[href="/series"]').click();
+    await expect(page).toHaveURL(/\/series/);
+
+    await expect(page.locator('.series-section').first()).toBeVisible();
+    await page.locator('.volume').first().click();
+
+    await expect(page).toHaveURL(/\/book\/\d+/);
+  });
+
+  test('should expand an author accordion to reveal their books', async ({ page }) => {
+    await loginViaUi(page, testUser.username, testUser.password);
+    await page.locator('.nav-tabs a[href="/authors"]').click();
+    await expect(page).toHaveURL(/\/authors/);
+
+    const firstAuthor = page.locator('.author-section').first();
+    await expect(firstAuthor).toHaveClass(/collapsed/);
+    await expect(firstAuthor.locator('.books-grid')).toHaveCount(0);
+
+    await firstAuthor.locator('.author-header').click();
+    await expect(firstAuthor).not.toHaveClass(/collapsed/);
+    await expect(firstAuthor.locator('.books-grid .mini-book').first()).toBeVisible();
+
+    await firstAuthor.locator('.mini-book').first().click();
+    await expect(page).toHaveURL(/\/book\/\d+/);
+  });
+
+  test('should select a tag, show its filtered books, then clear the filter', async ({ page }) => {
+    await loginViaUi(page, testUser.username, testUser.password);
+    await page.locator('.nav-tabs a[href="/tags"]').click();
+    await expect(page).toHaveURL(/\/tags/);
+
+    await expect(page.locator('.clear-filter')).toHaveCount(0);
+
+    const firstTag = page.locator('.tag-pill').first();
+    await firstTag.click();
+
+    await expect(page.locator('.filtered-books-grid .filtered-book').first()).toBeVisible();
+    await expect(page.locator('.clear-filter')).toBeVisible();
+
+    await page.locator('.clear-filter').click();
+    await expect(page.locator('.filtered-books-grid')).toHaveCount(0);
+  });
+});

--- a/apps/frontend-e2e-playwright/tests/ui-navigation.spec.ts
+++ b/apps/frontend-e2e-playwright/tests/ui-navigation.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { loginViaUi, testUser } from './helpers';
+
+/**
+ * Browser-driven navigation: the header's nav tabs, search box, sort/lang
+ * toolbar and theme toggle - the app shell delivered in PR2/PR3.
+ */
+test.describe('UI - Navigation', () => {
+  test('should switch between the header nav tabs', async ({ page }) => {
+    await loginViaUi(page, testUser.username, testUser.password);
+
+    await page.locator('.nav-tabs a[href="/books"]').click();
+    await expect(page).toHaveURL(/\/books/);
+    await expect(page.locator('.nav-tabs a[href="/books"]')).toHaveClass(/active/);
+
+    await page.locator('.nav-tabs a[href="/series"]').click();
+    await expect(page).toHaveURL(/\/series/);
+    await expect(page.locator('.nav-tabs a[href="/series"]')).toHaveClass(/active/);
+
+    await page.locator('.nav-tabs a[href="/authors"]').click();
+    await expect(page).toHaveURL(/\/authors/);
+
+    await page.locator('.nav-tabs a[href="/tags"]').click();
+    await expect(page).toHaveURL(/\/tags/);
+
+    await page.locator('.nav-tabs a[href="/home"]').click();
+    await expect(page).toHaveURL(/\/home/);
+  });
+
+  test('should filter the books list via the header search box', async ({ page }) => {
+    await loginViaUi(page, testUser.username, testUser.password);
+    await page.locator('.nav-tabs a[href="/books"]').click();
+    await expect(page).toHaveURL(/\/books/);
+
+    await page.locator('.search input').fill('zzz_nonexistent_book_xyz_12345');
+    await page.waitForTimeout(600);
+
+    await expect(page.locator('.empty-title')).toBeVisible();
+  });
+
+  test('should toggle the dark theme', async ({ page }) => {
+    await loginViaUi(page, testUser.username, testUser.password);
+
+    await expect(page.locator('html')).not.toHaveClass(/dark-theme/);
+    await page.locator('.theme-toggle').click();
+    await expect(page.locator('html')).toHaveClass(/dark-theme/);
+
+    await page.locator('.theme-toggle').click();
+    await expect(page.locator('html')).not.toHaveClass(/dark-theme/);
+  });
+
+  test('should change sort order from the sort menu on the books page', async ({ page }) => {
+    await loginViaUi(page, testUser.username, testUser.password);
+    await page.locator('.nav-tabs a[href="/books"]').click();
+    await expect(page).toHaveURL(/\/books/);
+
+    await page.locator('.sort-toggle').click();
+    await page.locator('.sort-menu button', { hasText: /author/i }).click();
+
+    await expect(page.locator('.sort-toggle')).toContainText(/author/i);
+  });
+});

--- a/apps/frontend-e2e-playwright/tests/ui-news-home.spec.ts
+++ b/apps/frontend-e2e-playwright/tests/ui-news-home.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+import { loginViaUi, testUser } from './helpers';
+
+/**
+ * Browser-driven news/home page (PR8): grouped "added" sections and
+ * clicking through to a book's detail page.
+ */
+test.describe('UI - News/home', () => {
+  test('should show grouped news sections and open a book from a row', async ({ page }) => {
+    await loginViaUi(page, testUser.username, testUser.password);
+
+    await expect(page.locator('.news-group').first()).toBeVisible();
+    await expect(page.locator('.group-header h2').first()).toBeVisible();
+    await expect(page.locator('.news-row').first()).toBeVisible();
+
+    await page.locator('.news-row').first().click();
+    await expect(page).toHaveURL(/\/book\/\d+/);
+  });
+});

--- a/apps/frontend-e2e-playwright/tests/ui-profile.spec.ts
+++ b/apps/frontend-e2e-playwright/tests/ui-profile.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+import { loginViaUi, testUser, adminUser } from './helpers';
+
+/**
+ * Browser-driven profile page (PR7): identity banner, account fields,
+ * Kindle addresses, linked accounts and the inline password card.
+ *
+ * Destructive/order-sensitive interactions (saving profile edits, changing
+ * the password, deleting the account) are exercised on the dedicated
+ * `deletableuser` fixture in ui-admin.spec.ts, in a single test, so their
+ * relative order is guaranteed regardless of Playwright's fullyParallel
+ * scheduling. This file only covers read-only/non-mutating checks that are
+ * safe to run concurrently with the rest of the suite.
+ */
+test.describe('UI - Profile', () => {
+  test('should show the identity banner for the logged in user', async ({ page }) => {
+    await loginViaUi(page, testUser.username, testUser.password);
+    await page.goto('/profile');
+
+    await expect(page.locator('.identity-info h1')).toContainText(testUser.username, { ignoreCase: true });
+    await expect(page.locator('.identity-banner .avatar')).toBeVisible();
+  });
+
+  test('should show the administration button only for an admin user', async ({ page }) => {
+    await loginViaUi(page, adminUser.username, adminUser.password);
+    await page.goto('/profile');
+    await expect(page.locator('.identity-actions .pill-accent')).toBeVisible();
+
+    await page.locator('.identity-actions .pill-accent').click();
+    await expect(page).toHaveURL(/\/users/);
+  });
+
+  test('should not show the administration button for a regular user', async ({ page }) => {
+    await loginViaUi(page, testUser.username, testUser.password);
+    await page.goto('/profile');
+    await expect(page.locator('.identity-actions .pill-accent')).toHaveCount(0);
+  });
+
+  test('should show the linked-accounts connect buttons', async ({ page }) => {
+    await loginViaUi(page, testUser.username, testUser.password);
+    await page.goto('/profile');
+
+    await expect(page.locator('.pill-google')).toBeVisible();
+    await expect(page.locator('.pill-facebook')).toBeVisible();
+  });
+
+  test('should reflect password validation states without submitting', async ({ page }) => {
+    await loginViaUi(page, testUser.username, testUser.password);
+    await page.goto('/profile');
+
+    const submit = page.locator('button[type=submit]', { hasText: /password|mot de passe/i });
+    await expect(submit).toBeDisabled();
+
+    // The component's password-matching logic is wired to (keyup)/(change),
+    // not just ngModel's own "input" listener - .fill() sets the value
+    // without dispatching either, so it never reaches PasswordState. Type
+    // the characters for real so those handlers actually run.
+    await page.locator('#changepw-password1').pressSequentially('abcdef');
+    await page.locator('#changepw-password2').pressSequentially('different');
+    await expect(page.locator('.hint-error')).toBeVisible();
+    await expect(submit).toBeDisabled();
+
+    await page.locator('#changepw-password2').fill('');
+    await page.locator('#changepw-password2').pressSequentially('abcdef');
+    await expect(page.locator('.hint-error')).toHaveCount(0);
+    await expect(submit).toBeEnabled();
+  });
+});


### PR DESCRIPTION
## Summary
- The existing Playwright suite was 100% API/HTTP-level, with no real browser interaction test despite the full 8-PR "Reliure" UI redesign changing every page's rendered markup.
- Add 7 new `ui-*.spec.ts` files that drive the actual UI through a real browser: `ui-auth` (login/signup/logout forms), `ui-navigation` (header tabs, search, theme toggle, sort menu), `ui-book-detail` (open/rate a book, author/tag pill links, EPUB/MOBI/Kindle dialog), `ui-library-lists` (series volumes, author accordion, tag filtering), `ui-profile` (identity banner, admin-only button, linked-accounts buttons, password validation states), `ui-admin` (access control, sorting, expandable summary row, merge select/unselect toggle, and a full lifecycle test on a dedicated throwaway `deletableuser` fixture), and `ui-news-home` (grouped sections, click-through to a book).
- Add a 3rd fixture user (`deletableuser`) to the Mongo stub for the admin lifecycle test, plus a `loginViaUi()` helper in `tests/helpers.ts`.
- Update `apps/frontend-e2e-playwright/README.md` to document the new UI-driven coverage alongside the existing API-level one.

## Test plan
- [x] `npm run e2e:playwright` — 96/96 passing (existing suite + all 7 new files, run together)
- [x] `npm run test:api` — 369/369 passing
- [x] `npm run test:frontend` — 499/499 passing
- [x] `npx nx lint frontend` — 0 errors (319 pre-existing warnings, unrelated to this branch)
- [x] `npm run start:api` / `npm run start:frontend` — both boot cleanly

## Note
While writing the profile-edit test, found a pre-existing timing bug (out of scope, left unfixed per project conventions on not touching functional code without explicit go-ahead): `UserService.checkAuthent()` polls every 3s for the page's lifetime and unconditionally rebuilds the in-memory user object from the JWT, which can race the 500ms debounced profile-field autosave and drop an in-flight edit before it reaches the backend. The affected test only asserts that typing reaches the field, not that the autosave commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAQKQ1Zox4YWmvy4FjDJC4


---
_Generated by [Claude Code](https://claude.ai/code/session_01LAQKQ1Zox4YWmvy4FjDJC4)_